### PR TITLE
Improve Outline chart

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/outline
   - https://github.com/outline/outline
 type: application
-version: 1.0.2
+version: 1.0.3

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -54,7 +54,7 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
 | outline.database_url | string | `"postgres://outline:secretPassword@outline-postgresql:5432/outline"` | Connection string to access the database |
 | outline.file_storage | string | `"local"` | Specify what storage system to use. Possible value is one of "s3" or "local". |
-| outline.file_storage_upload_max_size | int | `50000000` | Maximum allowed byte size for the uploaded attachment. |
+| outline.file_storage_upload_max_size | string | `"50000000"` | Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string. |
 | outline.pgsslmode | string | `"disable"` | Disable SSL for connecting to PostgreSQL |
 | outline.redis_url | string | `"redis://outline-redis-master:6379"` | Connection string to access Redis |
 | outline.secret_key | string | `""` | Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32` in your terminal to generate a random value. |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -76,8 +76,10 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | resources.limits.memory | string | `"1Gi"` | The maximum amount of memory the container can use |
 | resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
 | resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| scheduler.annotations | object | `{}` | Optional additional annotations to add to the CronJob runner pod |
 | scheduler.concurrencyPolicy | string | `"Forbid"` | Concurrency policy for the CronJob |
 | scheduler.enabled | bool | `true` | Create a CronJob to run Outline's scheduled jobs. Refer to <https://docs.getoutline.com/s/hosting/doc/scheduled-jobs-RhZzCt770H> for more information. |
+| scheduler.labels | object | `{}` | Optional additional labels to add to the CronJob runner pod |
 | scheduler.schedule | string | `"30 12 * * *"` | Schedule to use for the CronJob |
 | scheduler.timeZone | string | `"Europe/Budapest"` | Timezone for interpreting the cron schedule |
 | securityContext | object | `{}` | Run containers as a specific securityContext |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -1,6 +1,6 @@
 # outline
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.81.1](https://img.shields.io/badge/AppVersion-0.81.1-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.81.1](https://img.shields.io/badge/AppVersion-0.81.1-informational?style=flat-square)
 
 Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -12,6 +12,16 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          {{- with .Values.scheduler.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "outline.labels" . | nindent 12 }}
+            {{- with .Values.scheduler.labels }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           automountServiceAccountToken: false
           securityContext:

--- a/charts/outline/templates/pvc.yaml
+++ b/charts/outline/templates/pvc.yaml
@@ -11,5 +11,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
   storageClassName: {{ .Values.persistence.storageClass }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -33,7 +33,8 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000 -- Set the shared file system group for all containers in the pod
+  # -- Set the shared file system group for all containers in the pod
+  # fsGroup: 2000
 
 # -- Run containers as a specific securityContext
 securityContext: {}
@@ -94,8 +95,11 @@ persistence:
   accessMode: ReadWriteOnce
   # -- Defines the amount of storage allocated for persistence
   size: 2Gi
-  # You can also use an existing claim instead of creating one
+  # -- You can also use an existing claim instead of creating one
   # existingClaim: "myClaim"
+  # -- If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+  # If the value is "-" or not defined, volume.alpha.kubernetes.io/storage-class: default
+  # storageClass:
 
 autoscaling:
   # -- Controls whether autoscaling is enabled or disabled for the application

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -195,6 +195,10 @@ scheduler:
   timeZone: Europe/Budapest
   # -- Concurrency policy for the CronJob
   concurrencyPolicy: Forbid
+  # -- Optional additional annotations to add to the CronJob runner pod
+  annotations: {}
+  # -- Optional additional labels to add to the CronJob runner pod
+  labels: {}
 
 minio:
   # -- Enable the Bitnami MinIO® chart.

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -182,8 +182,8 @@ outline:
   # -- Specify what storage system to use. Possible value is one of "s3" or "local".
   file_storage: local
 
-  # -- Maximum allowed byte size for the uploaded attachment.
-  file_storage_upload_max_size: 50000000
+  # -- Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string.
+  file_storage_upload_max_size: "50000000"
 
 scheduler:
   # -- Create a CronJob to run Outline's scheduled jobs.


### PR DESCRIPTION
1. **Fix PVC configuration:**
Resolve an issue where multiple runs of `helm install` would fail. The first run sets the PVC to the default `StorageClassName` when no value is provided. Subsequent runs fail because the empty value does not match the default value automatically set by the cluster.
 
2. **Add annotations and labels to CronJob runner pod:**
Introduce an option to add annotations and labels to the CronJob runner pod, enabling users to customize the runner pod. For example, users can disable Istio's sidecar injection by adding appropriate annotations.
 
3. **Define max upload size as a string:**
Define the maximum upload size as a string to prevent unwanted scientific notation. Previously, `50000000` was converted to `5e+07`, which was not recognized by the application.