### PR TITLE
Fix warning in pre-commit run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         name: Detect secrets
         exclude: ^charts/
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.31.2
     hooks:
       - id: typos
         name: Run spell checker


### PR DESCRIPTION
Use fully specified version for typos hook