### PR TITLE
Replace Bitnami charts

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,19 +1,9 @@
 ---
 misconfigurations:
-  - id: AVD-KSV-0020
+  - id: AVD-KSV-0014
     paths:
-      - charts/outline/charts/postgresql/templates/primary/statefulset.yaml
-      - charts/outline/charts/redis/templates/master/application.yaml
-    statement: External charts
-  - id: AVD-KSV-0021
-    paths:
-      - charts/outline/charts/postgresql/templates/primary/statefulset.yaml
-      - charts/outline/charts/redis/templates/master/application.yaml
-    statement: External charts
-  - id: AVD-KSV-0109
-    paths:
-      - charts/outline/charts/redis/templates/health-configmap.yaml
-      - charts/outline/charts/redis/templates/scripts-configmap.yaml
+      - charts/outline/charts/postgres/templates/statefulset.yaml
+      - charts/outline/charts/redis/templates/statefulset.yaml
     statement: External charts
   - id: AVD-KSV-0110
     paths:

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -4,16 +4,16 @@ appVersion: 0.85.1
 dependencies:
   - condition: minio.enabled
     name: minio
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 17.x.x
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 16.x.x
+    repository: oci://registry-1.docker.io/cloudpirates
+    version: 0.2.1
+  - condition: postgres.enabled
+    name: postgres
+    repository: oci://registry-1.docker.io/cloudpirates
+    version: 0.2.5
   - condition: redis.enabled
     name: redis
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 22.x.x
+    repository: oci://registry-1.docker.io/cloudpirates
+    version: 0.2.1
 description: Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 home: https://www.getoutline.com
 icon: https://www.getoutline.com/images/logo.svg
@@ -30,4 +30,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/outline
   - https://github.com/outline/outline
 type: application
-version: 1.1.3
+version: 1.2.0

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -68,8 +68,23 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | postgres.auth.database | string | `"outline"` | Name for a custom database to create |
 | postgres.auth.username | string | `"outline"` | Name for a custom user to create |
 | postgres.enabled | bool | `true` | Enable the CloudPirates PostgreSQL chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres> for possible values. |
+| postgres.resources.limits.cpu | string | `"500m"` | The maximum amount of CPU the container can use |
+| postgres.resources.limits.memory | string | `"512Mi"` | The maximum amount of memory the container can use |
+| postgres.resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| postgres.resources.requests.memory | string | `"256Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| postgres.securityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
+| postgres.securityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |
+| postgres.securityContext.seccompProfile.type | string | `"RuntimeDefault"` | Use the container runtime default seccomp profile |
 | redis.auth.enabled | bool | `false` | Enable password authentication |
+| redis.containerSecurityContext.capabilities.drop | list | `["ALL"]` | Drop all capabilities for improved security |
+| redis.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
+| redis.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |
+| redis.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Use the container runtime default seccomp profile |
 | redis.enabled | bool | `true` | Enable the CloudPirates Redis® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis> for possible values. |
+| redis.resources.limits.cpu | string | `"150m"` | The maximum amount of CPU the container can use |
+| redis.resources.limits.memory | string | `"256Mi"` | The maximum amount of memory the container can use |
+| redis.resources.requests.cpu | string | `"50m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| redis.resources.requests.memory | string | `"128Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | replicaCount | int | `1` | The number of replicas to deploy |
 | resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
 | resources.limits.memory | string | `"1Gi"` | The maximum amount of memory the container can use |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -1,6 +1,6 @@
 # outline
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.85.1](https://img.shields.io/badge/AppVersion-0.85.1-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.85.1](https://img.shields.io/badge/AppVersion-0.85.1-informational?style=flat-square)
 
 Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 
@@ -21,9 +21,9 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | minio | 17.x.x |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.x.x |
-| oci://registry-1.docker.io/bitnamicharts | redis | 22.x.x |
+| oci://registry-1.docker.io/cloudpirates | minio | 0.2.1 |
+| oci://registry-1.docker.io/cloudpirates | postgres | 0.2.5 |
+| oci://registry-1.docker.io/cloudpirates | redis | 0.2.1 |
 
 ## Values
 
@@ -48,15 +48,14 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | ingress.hosts | list | `[]` | List of ingress hosts |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | Init containers to add to the deployment |
-| minio.defaultBuckets | string | `"outline"` | Comma, semi-colon or space separated list of buckets to create at initialization |
-| minio.enabled | bool | `false` | Enable the Bitnami MinIO® chart. Refer to <https://github.com/bitnami/charts/blob/main/bitnami/minio> for possible values. |
+| minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
 | nameOverride | string | `""` | Provide a name in place of `outline`. Prefer using global.nameOverride if possible |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
-| outline.database_url | string | `"postgres://outline:secretPassword@outline-postgresql:5432/outline"` | Connection string to access the database |
+| outline.database_url | string | `"postgres://outline:secretPassword@outline-postgres:5432/outline"` | Connection string to access the database |
 | outline.file_storage | string | `"local"` | Specify what storage system to use. Possible value is one of "s3" or "local". |
 | outline.file_storage_upload_max_size | string | `"50000000"` | Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string. |
 | outline.pgsslmode | string | `"disable"` | Disable SSL for connecting to PostgreSQL |
-| outline.redis_url | string | `"redis://outline-redis-master:6379"` | Connection string to access Redis |
+| outline.redis_url | string | `"redis://outline-redis:6379"` | Connection string to access Redis |
 | outline.secret_key | string | `""` | Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32` in your terminal to generate a random value. |
 | outline.url | string | `"https://outline.example.com"` | URL should point to the fully qualified, publicly accessible URL. |
 | outline.utils_secret | string | `""` | Generate a unique random key. The format is not important but you could still use `openssl rand -hex 32` in your terminal to produce this. |
@@ -66,13 +65,11 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | podAnnotations | object | `{}` | Optional additional annotations to add to the pods |
 | podLabels | object | `{}` | Optional additional labels to add to the pods |
 | podSecurityContext | object | `{}` |  |
-| postgresql.auth.database | string | `"outline"` | Name for a custom database to create |
-| postgresql.auth.username | string | `"outline"` | Name for a custom user to create |
-| postgresql.enabled | bool | `true` | Enable the Bitnami PostgreSQL chart. Refer to <https://github.com/bitnami/charts/blob/main/bitnami/postgresql> for possible values. |
-| redis.architecture | string | `"standalone"` | Redis® architecture. Allowed values: standalone or replication |
+| postgres.auth.database | string | `"outline"` | Name for a custom database to create |
+| postgres.auth.username | string | `"outline"` | Name for a custom user to create |
+| postgres.enabled | bool | `true` | Enable the CloudPirates PostgreSQL chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres> for possible values. |
 | redis.auth.enabled | bool | `false` | Enable password authentication |
-| redis.auth.usePasswordFiles | bool | `false` | Workaround until behaviour introduced by <https://github.com/bitnami/charts/pull/32117> is changed |
-| redis.enabled | bool | `true` | Enable the Bitnami Redis® chart. Refer to <https://github.com/bitnami/charts/blob/main/bitnami/redis> for possible values. |
+| redis.enabled | bool | `true` | Enable the CloudPirates Redis® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis> for possible values. |
 | replicaCount | int | `1` | The number of replicas to deploy |
 | resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
 | resources.limits.memory | string | `"1Gi"` | The maximum amount of memory the container can use |

--- a/charts/outline/ci/default-values.yaml
+++ b/charts/outline/ci/default-values.yaml
@@ -2,9 +2,9 @@
 outline:
   secret_key: 96250aac910f511334f52e9b609713305abb5bf8329188879fcc1c5b3e983aa4
   utils_secret: 69e576155ecfbc380ccb5d7a7293a6e97aca9039e22f5ecadf8f0d49c266879e
-  database_url: postgres://outline:secretPassword@{{ include "outline.fullname" . }}-postgresql:5432/outline
-  redis_url: redis://{{ include "outline.fullname" . }}-redis-master:6379
+  database_url: postgres://outline:secretPassword@{{ include "outline.fullname" . }}-postgres:5432/outline
+  redis_url: redis://{{ include "outline.fullname" . }}-redis:6379
 
-postgresql:
+postgres:
   auth:
     password: secretPassword

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -47,7 +47,7 @@ securityContext: {}
 
 # -- Init containers to add to the deployment
 initContainers: []
-  # - name: wait-for-postgresql
+  # - name: wait-for-postgres
   #   image: busybox:latest
   #   command: ['sh', '-c', 'do-something-here']
 
@@ -170,13 +170,13 @@ outline:
   utils_secret: ""
 
   # -- Connection string to access the database
-  database_url: postgres://outline:secretPassword@outline-postgresql:5432/outline
+  database_url: postgres://outline:secretPassword@outline-postgres:5432/outline
 
   # -- Disable SSL for connecting to PostgreSQL
   pgsslmode: disable
 
   # -- Connection string to access Redis
-  redis_url: redis://outline-redis-master:6379
+  redis_url: redis://outline-redis:6379
 
   # -- URL should point to the fully qualified, publicly accessible URL.
   url: https://outline.example.com
@@ -203,15 +203,13 @@ scheduler:
   labels: {}
 
 minio:
-  # -- Enable the Bitnami MinIO® chart.
-  # Refer to <https://github.com/bitnami/charts/blob/main/bitnami/minio> for possible values.
+  # -- Enable the CloudPirates MinIO® chart.
+  # Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values.
   enabled: false
-  # -- Comma, semi-colon or space separated list of buckets to create at initialization
-  defaultBuckets: outline
 
-postgresql:
-  # -- Enable the Bitnami PostgreSQL chart.
-  # Refer to <https://github.com/bitnami/charts/blob/main/bitnami/postgresql> for possible values.
+postgres:
+  # -- Enable the CloudPirates PostgreSQL chart.
+  # Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres> for possible values.
   enabled: true
   auth:
     # -- Name for a custom user to create
@@ -221,13 +219,9 @@ postgresql:
     # password: "secretPassword"
 
 redis:
-  # -- Enable the Bitnami Redis® chart.
-  # Refer to <https://github.com/bitnami/charts/blob/main/bitnami/redis> for possible values.
+  # -- Enable the CloudPirates Redis® chart.
+  # Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis> for possible values.
   enabled: true
-  # -- Redis® architecture. Allowed values: standalone or replication
-  architecture: standalone
   auth:
     # -- Enable password authentication
     enabled: false
-    # -- Workaround until behaviour introduced by <https://github.com/bitnami/charts/pull/32117> is changed
-    usePasswordFiles: false

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -217,6 +217,25 @@ postgres:
     # -- Name for a custom database to create
     database: outline
     # password: "secretPassword"
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 500m
+      # -- The maximum amount of memory the container can use
+      memory: 512Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 250m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 256Mi
+  securityContext:
+    # -- Run container processes as non-root user nobody
+    runAsUser: 65534
+    # -- Run container processes with nobody group
+    runAsGroup: 65534
+    seccompProfile:
+      # -- Use the container runtime default seccomp profile
+      type: RuntimeDefault
 
 redis:
   # -- Enable the CloudPirates Redis® chart.
@@ -225,3 +244,26 @@ redis:
   auth:
     # -- Enable password authentication
     enabled: false
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 150m
+      # -- The maximum amount of memory the container can use
+      memory: 256Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 50m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 128Mi
+  containerSecurityContext:
+    # -- Run container processes as non-root user nobody
+    runAsUser: 65534
+    # -- Run container processes with nobody group
+    runAsGroup: 65534
+    seccompProfile:
+      # -- Use the container runtime default seccomp profile
+      type: RuntimeDefault
+    capabilities:
+      # -- Drop all capabilities for improved security
+      drop:
+        - ALL


### PR DESCRIPTION
Bitnami announced changes to their free container images and Helm charts:
- Versioned images are being moved to `bitnamilegacy` and will no longer receive updates or security patches.
- Free tier images are limited to `latest` tags only, which are not recommended for production use due to lack of version pinning and stability.
- Hardened, supported images are now part of a paid subscription, making them unsuitable for open-source, hobby, or freely distributable charts.

To ensure long-term stability and security, this PR replaces Bitnami charts with community-maintained alternatives that use official images (Postgres, Redis, MinIO).

This keeps the chart free, versioned, and reproducible while giving users full control over when images are upgraded.