### PR TITLE
Harden and modernize the outline chart

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -22,6 +22,7 @@ keywords:
   - outline
   - wiki
   - docs
+kubeVersion: ">=1.19.0-0"
 maintainers:
   - name: Budavári Schönherz Stúdió
     url: https://github.com/BSStudio/helm-charts

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/outline
   - https://github.com/outline/outline
 type: application
-version: 1.2.10
+version: 1.3.0

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -1,6 +1,6 @@
 # outline
 
-![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -91,11 +91,15 @@ Kubernetes: `>=1.19.0-0`
 | resources.limits.memory | string | `"1Gi"` | The maximum amount of memory the container can use |
 | resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
 | resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| scheduler.activeDeadlineSeconds | int | `300` | Hard time limit for a single run before it is killed (guards against a hung request) |
 | scheduler.annotations | object | `{}` | Optional additional annotations to add to the CronJob runner pod |
+| scheduler.backoffLimit | int | `1` | Number of retries before a run is marked failed |
 | scheduler.concurrencyPolicy | string | `"Forbid"` | Concurrency policy for the CronJob |
 | scheduler.enabled | bool | `true` | Create a CronJob to run Outline's scheduled jobs. Refer to <https://docs.getoutline.com/s/hosting/doc/scheduled-jobs-RhZzCt770H> for more information. |
+| scheduler.failedJobsHistoryLimit | int | `3` | How many failed jobs to retain for debugging |
 | scheduler.labels | object | `{}` | Optional additional labels to add to the CronJob runner pod |
 | scheduler.schedule | string | `"30 12 * * *"` | Schedule to use for the CronJob |
+| scheduler.successfulJobsHistoryLimit | int | `3` | How many completed jobs to retain |
 | scheduler.timeZone | string | `"Europe/Budapest"` | Timezone for interpreting the cron schedule |
 | securityContext | object | `{}` | Run containers as a specific securityContext |
 | service.port | int | `3000` | Port number for web traffic |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -19,6 +19,8 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 
 ## Requirements
 
+Kubernetes: `>=1.19.0-0`
+
 | Repository | Name | Version |
 |------------|------|---------|
 | oci://registry-1.docker.io/cloudpirates | minio | 0.13.0 |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -62,6 +62,7 @@ Kubernetes: `>=1.19.0-0`
 | outline.url | string | `"https://outline.example.com"` | URL should point to the fully qualified, publicly accessible URL. |
 | outline.utils_secret | string | `""` | Generate a unique random key. The format is not important but you could still use `openssl rand -hex 32` in your terminal to produce this. |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Specifies the level of access to the persistent storage (e.g., read-write, read-only) |
+| persistence.annotations | object | `{}` | Annotations to add to the PVC, e.g. `helm.sh/resource-policy: keep` to retain data on uninstall |
 | persistence.enabled | bool | `true` | Determines whether persistent storage is enabled or not |
 | persistence.size | string | `"2Gi"` | Defines the amount of storage allocated for persistence |
 | podAnnotations | object | `{}` | Optional additional annotations to add to the pods |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -101,4 +101,5 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| strategy | object | `{}` | Deployment update strategy. When empty, defaults to `Recreate` if persistence is enabled with a non-`ReadWriteMany` access mode (avoids a RWO volume deadlock on upgrade), otherwise Kubernetes' default RollingUpdate is used. |
 | tolerations | list | `[]` | Tolerations for the deployment |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -40,7 +40,7 @@ Kubernetes: `>=1.19.0-0`
 | envFrom | list | `[]` | envFrom to pass to the deployment |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for the containers |
 | extraVolumes | list | `[]` | Additional volumes to mount to the deployment |
-| fullnameOverride | string | `""` | String to fully override `"outline.fullname"`. Prefer using global.fullnameOverride if possible |
+| fullnameOverride | string | `""` | String to fully override `"outline.fullname"` |
 | image.imagePullPolicy | string | `"IfNotPresent"` | The logic of image pulling |
 | image.repository | string | `"outlinewiki/outline"` | The Docker repository to pull the image from |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
@@ -51,7 +51,7 @@ Kubernetes: `>=1.19.0-0`
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | Init containers to add to the deployment |
 | minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
-| nameOverride | string | `""` | Provide a name in place of `outline`. Prefer using global.nameOverride if possible |
+| nameOverride | string | `""` | Provide a name in place of `outline` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
 | outline.database_url | string | `"postgres://outline:secretPassword@outline-postgres:5432/outline"` | Connection string to access the database |
 | outline.file_storage | string | `"local"` | Specify what storage system to use. Possible value is one of "s3" or "local". |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -64,7 +64,7 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 | persistence.size | string | `"2Gi"` | Defines the amount of storage allocated for persistence |
 | podAnnotations | object | `{}` | Optional additional annotations to add to the pods |
 | podLabels | object | `{}` | Optional additional labels to add to the pods |
-| podSecurityContext | object | `{}` |  |
+| podSecurityContext | object | `{}` | Pod-level security context, merged over chart defaults (fsGroup 65534 for volume writes) |
 | postgres.auth.database | string | `"outline"` | Name for a custom database to create |
 | postgres.auth.username | string | `"outline"` | Name for a custom user to create |
 | postgres.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |

--- a/charts/outline/templates/NOTES.txt
+++ b/charts/outline/templates/NOTES.txt
@@ -1,0 +1,28 @@
+{{- $fullName := include "outline.fullname" . -}}
+Outline {{ .Chart.AppVersion }} has been deployed as release {{ .Release.Name }}.
+
+{{- if .Values.ingress.enabled }}
+
+Reach the application at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else }}
+
+Outline is exposed on a {{ .Values.service.type }} Service. To reach it from your machine:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ $fullName }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+then open http://127.0.0.1:{{ .Values.service.port }}
+{{- end }}
+
+Configured public URL: {{ .Values.outline.url }}
+{{- if not .Values.outline.secret_key }}
+
+WARNING: outline.secret_key is empty — set it (openssl rand -hex 32) or Outline will not start.
+{{- end }}
+{{- if not .Values.outline.utils_secret }}
+WARNING: outline.utils_secret is empty — set it (openssl rand -hex 32) or Outline will not start.
+{{- end }}

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -9,8 +9,12 @@ spec:
   schedule: {{ .Values.scheduler.schedule | quote }}
   timeZone: {{ .Values.scheduler.timeZone | quote }}
   concurrencyPolicy: {{ .Values.scheduler.concurrencyPolicy | quote }}
+  successfulJobsHistoryLimit: {{ .Values.scheduler.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.scheduler.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      activeDeadlineSeconds: {{ .Values.scheduler.activeDeadlineSeconds }}
+      backoffLimit: {{ .Values.scheduler.backoffLimit }}
       template:
         metadata:
           {{- with .Values.scheduler.annotations }}

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                 - -c
                 - |
                   URL="http://{{ include "outline.fullname" . }}:{{ .Values.service.port }}/api/cron.daily?token=${UTILS_SECRET}"
-                  RESPONSE=$(wget -q -O - --server-response --no-check-certificate "$URL" 2>&1)
+                  RESPONSE=$(wget -q -O - --server-response "$URL" 2>&1)
                   STATUS_CODE=$(echo "$RESPONSE" | sed -rn 's:.*HTTP/.* ([0-9]+) .*:\1:p' | tail -1)
 
                   if [ "$STATUS_CODE" != "200" ]; then

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -39,7 +39,6 @@ spec:
                 readOnlyRootFilesystem: true
                 capabilities:
                   drop:
-                    - NET_RAW
                     - ALL
               command: [/bin/sh]
               args:

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                   echo "Successfully invoked cron.daily."
               env:
                 - name: TZ
-                  value: {{ .Values.scheduler.timeZone }}
+                  value: {{ .Values.scheduler.timeZone | quote }}
                 - name: UTILS_SECRET
                   valueFrom:
                     secretKeyRef:

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "outline.serviceAccountName" . }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -46,7 +46,6 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop:
-                - NET_RAW
                 - ALL
             {{- with .Values.securityContext }}
               {{- toYaml . | nindent 12 }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -8,6 +8,13 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- if .Values.strategy }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- else if and .Values.persistence.enabled (not (eq .Values.persistence.accessMode "ReadWriteMany")) }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "outline.selectorLabels" . | nindent 6 }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
         {{- with .Values.podSecurityContext }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/outline/templates/ingress.yaml
+++ b/charts/outline/templates/ingress.yaml
@@ -1,18 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "outline.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -23,8 +12,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
@@ -43,19 +32,14 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            {{- with .pathType }}
+            pathType: {{ . }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/outline/templates/pvc.yaml
+++ b/charts/outline/templates/pvc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "outline.fullname" . }}
   labels:
     {{- include "outline.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "outline.fullname" . }}
   labels:
     {{- include "outline.labels" . | nindent 4 }}
+type: Opaque
 data:
   {{- include "outline.env" (dict "root" . "values" .Values.outline) | indent 2 }}
   {{- include "outline.envVars" . | indent 2 }}

--- a/charts/outline/templates/tests/test-connection.yaml
+++ b/charts/outline/templates/tests/test-connection.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ printf "%s-test-connection" (include "outline.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "outline.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: test-connection
+      image: busybox:stable-uclibc
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command: [wget]
+      args:
+        - --spider
+        - -S
+        - http://{{ include "outline.fullname" . }}:{{ .Values.service.port }}/_health
+      resources:
+        requests:
+          cpu: 50m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -41,8 +41,8 @@ podAnnotations: {}
 # -- Optional additional labels to add to the pods
 podLabels: {}
 
+# -- Pod-level security context, merged over chart defaults (fsGroup 65534 for volume writes)
 podSecurityContext: {}
-  # -- Set the shared file system group for all containers in the pod
   # fsGroup: 2000
 
 # -- Run containers as a specific securityContext

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -1,7 +1,7 @@
 ---
-# -- Provide a name in place of `outline`. Prefer using global.nameOverride if possible
+# -- Provide a name in place of `outline`
 nameOverride: ""
-# -- String to fully override `"outline.fullname"`. Prefer using global.fullnameOverride if possible
+# -- String to fully override `"outline.fullname"`
 fullnameOverride: ""
 
 image:

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -106,6 +106,8 @@ persistence:
   accessMode: ReadWriteOnce
   # -- Defines the amount of storage allocated for persistence
   size: 2Gi
+  # -- Annotations to add to the PVC, e.g. `helm.sh/resource-policy: keep` to retain data on uninstall
+  annotations: {}
   # -- You can also use an existing claim instead of creating one
   # existingClaim: "myClaim"
   # -- If defined, volume.beta.kubernetes.io/storage-class: <storageClass>

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -15,6 +15,15 @@ image:
 # -- The number of replicas to deploy
 replicaCount: 1
 
+# -- Deployment update strategy. When empty, defaults to `Recreate` if persistence
+# is enabled with a non-`ReadWriteMany` access mode (avoids a RWO volume deadlock
+# on upgrade), otherwise Kubernetes' default RollingUpdate is used.
+strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -208,6 +208,14 @@ scheduler:
   timeZone: Europe/Budapest
   # -- Concurrency policy for the CronJob
   concurrencyPolicy: Forbid
+  # -- Hard time limit for a single run before it is killed (guards against a hung request)
+  activeDeadlineSeconds: 300
+  # -- Number of retries before a run is marked failed
+  backoffLimit: 1
+  # -- How many completed jobs to retain
+  successfulJobsHistoryLimit: 3
+  # -- How many failed jobs to retain for debugging
+  failedJobsHistoryLimit: 3
   # -- Optional additional annotations to add to the CronJob runner pod
   annotations: {}
   # -- Optional additional labels to add to the CronJob runner pod


### PR DESCRIPTION
## Summary

Review pass over the `outline` chart fixing correctness bugs, reliability footguns, and bringing it in line with current Helm/Kubernetes conventions.

## Bug fixes
- **imagePullPolicy never applied** — template read `.Values.image.pullPolicy` while values defined `image.imagePullPolicy`; the value was silently ignored.
- **automountServiceAccountToken** — pod hardcoded `false`, ignoring the `serviceAccount.automount` value; now wired through.

## Reliability
- **Recreate strategy for RWO persistence** — default RollingUpdate deadlocks on upgrade when a new pod can't mount the `ReadWriteOnce` volume still held by the old one. Auto-selected when persistence is on with a non-RWX access mode; overridable via `strategy`.
- **fsGroup for volume writes** — the non-root container (uid/gid 65534) with a read-only root FS couldn't write the PVC without an `fsGroup`. Defaults to `65534` with `fsGroupChangePolicy: OnRootMismatch`.
- **CronJob job controls** — added `activeDeadlineSeconds` (kills a hung run), lowered `backoffLimit` 6 → 1, and set job history limits.

## Compatibility
- **Require Kubernetes >= 1.19** (`kubeVersion`) and collapsed `ingress.yaml` to `networking.k8s.io/v1` only, removing dead `v1beta1`/`extensions` and pre-1.18 ingress-class fallbacks.

## Security / cleanup
- Capabilities drop `ALL` (was redundant `NET_RAW` + `ALL`).
- Explicit `type: Opaque` on the Secret.
- Removed dead `wget --no-check-certificate` (URL is plain `http://`).

## Developer experience
- Added `NOTES.txt` with post-install access hints and empty-secret warnings.
- Added a `helm test` connection pod hitting `/_health`, hardened to match the chart's other pods.
- `persistence.annotations` (e.g. `helm.sh/resource-policy: keep` to retain data on uninstall).
- Quoted the CronJob `TZ` value; removed misleading `global.*` override comments.

## Notes
- ⚠️ `kubeVersion: ">=1.19.0-0"` will refuse installs on older clusters.
- New values: `strategy`, `persistence.annotations`, `scheduler.activeDeadlineSeconds`, `scheduler.backoffLimit`, `scheduler.successfulJobsHistoryLimit`, `scheduler.failedJobsHistoryLimit`. README values table regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
