### PR TITLE
Add Request Manager chart

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -32,6 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/configs
           VALIDATE_GIT_COMMITLINT: false
+          VALIDATE_JSCPD: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_SHELL_SHFMT: false

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -4,11 +4,20 @@ misconfigurations:
     paths:
       - charts/outline/charts/postgres/templates/statefulset.yaml
       - charts/outline/charts/redis/templates/statefulset.yaml
+      - charts/request-manager/charts/postgres/templates/statefulset.yaml
     statement: External charts
   - id: AVD-KSV-0110
     paths:
       - charts/outline/templates/cronjob.yaml
       - charts/outline/templates/deployment.yaml
+      - charts/request-manager/templates/beat/deployment.yaml
+      - charts/request-manager/templates/migrate-job.yaml
+      - charts/request-manager/templates/server/deployment.yaml
+      - charts/request-manager/templates/worker/deployment.yaml
     statement: Actual chart will not be deployed to default namespace
   - id: AVD-KSV-0125
     statement: Used container registries are trusted
+  - id: AVD-KSV-01010
+    paths:
+      - charts/request-manager/templates/configmap.yaml
+    statement: Actual chart will not be deployed to default namespace

--- a/charts/request-manager/.helmignore
+++ b/charts/request-manager/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 1.3.1
+appVersion: 1.3.2
 dependencies:
   - condition: postgres.enabled
     name: postgres

--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -19,7 +19,7 @@ keywords:
   - video-production
   - studio
   - bss
-kubeVersion: ">=1.19.0-0"
+kubeVersion: ">=1.23.0-0"
 maintainers:
   - name: Budavári Schönherz Stúdió
     url: https://github.com/BSStudio/helm-charts

--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v2
+appVersion: 1.3.1
+dependencies:
+  - condition: postgres.enabled
+    name: postgres
+    repository: oci://registry-1.docker.io/cloudpirates
+    version: 0.19.6
+  - condition: redis.enabled
+    name: redis
+    repository: oci://registry-1.docker.io/cloudpirates
+    version: 0.30.6
+description: Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
+home: https://github.com/KOliver94/bss-request-manager
+# image: ghcr.io/koliver94/bss-request-manager
+keywords:
+  - request-manager
+  - video-requests
+  - video-production
+  - studio
+  - bss
+kubeVersion: ">=1.19.0-0"
+maintainers:
+  - name: Budavári Schönherz Stúdió
+    url: https://github.com/BSStudio/helm-charts
+name: request-manager
+sources:
+  - https://github.com/BSStudio/helm-charts/tree/main/charts/request-manager
+  - https://github.com/KOliver94/bss-request-manager
+type: application
+version: 0.1.0

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -45,6 +45,7 @@ Kubernetes: `>=1.23.0-0`
 | credentials.fileName | string | `"service-account-key-file.json"` | Filename of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME) |
 | credentials.serviceAccountKey | string | `""` | Contents of the Google service account JSON key. Ignored when `existingSecret` is set. |
 | existingSecret | string | `""` | Supply the sensitive environment variables from an existing Secret instead of `secrets`. Its keys must be the environment variable names. DATABASE_PASSWORD stays chart-managed. |
+| extraEnv | list | `[]` | Additional environment variables, appended to every container verbatim. Prefer `config` and `secrets`; entries here take precedence over both. |
 | extraEnvFrom | list | `[]` | Additional envFrom sources appended to every container |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to every container |
 | extraVolumes | list | `[]` | Additional volumes added to every pod |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -68,7 +68,7 @@ Kubernetes: `>=1.23.0-0`
 | migrations.resources.requests.cpu | string | `"100m"` | Specifies the minimum amount of CPU that will be allocated to the container |
 | migrations.resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | migrations.ttlSecondsAfterFinished | int | `600` | How long a finished migration Job is retained before automatic cleanup |
-| migrations.waitForMigrations | bool | `true` | Block every pod in an initContainer until migrations are applied. Deliberately not in the readiness probe: that would flip healthy running pods to NotReady whenever new migrations ship. |
+| migrations.waitForMigrations | string | `migrations.enabled` | Block every pod in an initContainer until migrations are applied. Deliberately not in the readiness probe: that would flip healthy running pods to NotReady whenever new migrations ship. Set explicitly to wait even when the Job is disabled; pods then block until you migrate. |
 | migrations.waitTimeout | int | `300` | Seconds the initContainer waits for migrations before failing (the pod then retries) |
 | nameOverride | string | `""` | Provide a name in place of `request-manager` |
 | nodeSelector | object | `{}` | NodeSelector for all workloads |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -1,6 +1,6 @@
 # request-manager
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
 
 Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
 

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -39,7 +39,7 @@ Kubernetes: `>=1.19.0-0`
 | beat.resources.requests.memory | string | `"384Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | beat.terminationGracePeriodSeconds | int | `30` | Grace period for the beat scheduler to shut down |
 | config | object | `{"ALLOWED_HOSTS":"","DJANGO_SETTINGS_MODULE":"core.settings.production"}` | Non-secret environment variables rendered into a ConfigMap, shared by all roles. Keys are the literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>. Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts. |
-| config.ALLOWED_HOSTS | string | `""` | Comma separated list of allowed hosts. Must include your ingress host(s). |
+| config.ALLOWED_HOSTS | string | `""` | Comma separated list of extra allowed hosts, appended to the pod IP, localhost and the Service name that the chart always sets. Add your ingress host(s) here. |
 | credentials.enabled | bool | `false` | Mount a Google service account key file into the credentials directory. Required only if the Google Calendar integration is used. |
 | credentials.existingSecret | string | `""` | Use an existing Secret holding the key file instead of creating one from `serviceAccountKey` |
 | credentials.fileName | string | `"service-account-key-file.json"` | File name of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME) |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -44,7 +44,7 @@ Kubernetes: `>=1.23.0-0`
 | credentials.existingSecret | string | `""` | Use an existing Secret holding the key file instead of creating one from `serviceAccountKey` |
 | credentials.fileName | string | `"service-account-key-file.json"` | Filename of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME) |
 | credentials.serviceAccountKey | string | `""` | Contents of the Google service account JSON key. Ignored when `existingSecret` is set. |
-| existingSecret | string | `""` | Supply the sensitive environment variables from an existing Secret instead of `secrets`. The Secret's keys must match the expected environment variable names. |
+| existingSecret | string | `""` | Supply the sensitive environment variables from an existing Secret instead of `secrets`. Its keys must be the environment variable names. DATABASE_PASSWORD stays chart-managed. |
 | extraEnvFrom | list | `[]` | Additional envFrom sources appended to every container |
 | extraVolumeMounts | list | `[]` | Additional volume mounts added to every container |
 | extraVolumes | list | `[]` | Additional volumes added to every pod |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -42,7 +42,7 @@ Kubernetes: `>=1.23.0-0`
 | config.ALLOWED_HOSTS | string | `""` | Comma separated list of extra allowed hosts, appended to the pod IP, localhost and the Service name that the chart always sets. Add your ingress host(s) here. |
 | credentials.enabled | bool | `false` | Mount a Google service account key file into the credentials directory. Required only if the Google Calendar integration is used. |
 | credentials.existingSecret | string | `""` | Use an existing Secret holding the key file instead of creating one from `serviceAccountKey` |
-| credentials.fileName | string | `"service-account-key-file.json"` | File name of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME) |
+| credentials.fileName | string | `"service-account-key-file.json"` | Filename of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME) |
 | credentials.serviceAccountKey | string | `""` | Contents of the Google service account JSON key. Ignored when `existingSecret` is set. |
 | existingSecret | string | `""` | Supply the sensitive environment variables from an existing Secret instead of `secrets`. The Secret's keys must match the expected environment variable names. |
 | extraEnvFrom | list | `[]` | Additional envFrom sources appended to every container |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -1,0 +1,141 @@
+# request-manager
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.1](https://img.shields.io/badge/AppVersion-1.3.1-informational?style=flat-square)
+
+Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
+
+**Homepage:** <https://github.com/KOliver94/bss-request-manager>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Budavári Schönherz Stúdió |  | <https://github.com/BSStudio/helm-charts> |
+
+## Source Code
+
+* <https://github.com/BSStudio/helm-charts/tree/main/charts/request-manager>
+* <https://github.com/KOliver94/bss-request-manager>
+
+## Requirements
+
+Kubernetes: `>=1.19.0-0`
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://registry-1.docker.io/cloudpirates | postgres | 0.19.6 |
+| oci://registry-1.docker.io/cloudpirates | redis | 0.30.6 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity for all workloads |
+| beat.args | list | `["celery","-A","core","beat"]` | Container args for the Celery beat scheduler |
+| beat.livenessProbe | object | `{}` | Liveness probe for the beat container (disabled by default) |
+| beat.resources.limits.cpu | string | `"250m"` | The maximum amount of CPU the container can use |
+| beat.resources.limits.memory | string | `"384Mi"` | The maximum amount of memory the container can use |
+| beat.resources.requests.cpu | string | `"50m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| beat.resources.requests.memory | string | `"384Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| beat.terminationGracePeriodSeconds | int | `30` | Grace period for the beat scheduler to shut down |
+| config | object | `{"ALLOWED_HOSTS":"","DJANGO_SETTINGS_MODULE":"core.settings.production"}` | Non-secret environment variables rendered into a ConfigMap, shared by all roles. Keys are the literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>. Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts. |
+| config.ALLOWED_HOSTS | string | `""` | Comma separated list of allowed hosts. Must include your ingress host(s). |
+| credentials.enabled | bool | `false` | Mount a Google service account key file into the credentials directory. Required only if the Google Calendar integration is used. |
+| credentials.existingSecret | string | `""` | Use an existing Secret holding the key file instead of creating one from `serviceAccountKey` |
+| credentials.fileName | string | `"service-account-key-file.json"` | File name of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME) |
+| credentials.serviceAccountKey | string | `""` | Contents of the Google service account JSON key. Ignored when `existingSecret` is set. |
+| existingSecret | string | `""` | Supply the sensitive environment variables from an existing Secret instead of `secrets`. The Secret's keys must match the expected environment variable names. |
+| extraEnvFrom | list | `[]` | Additional envFrom sources appended to every container |
+| extraVolumeMounts | list | `[]` | Additional volume mounts added to every container |
+| extraVolumes | list | `[]` | Additional volumes added to every pod |
+| fullnameOverride | string | `""` | String to fully override `"request-manager.fullname"` |
+| image.imagePullPolicy | string | `"IfNotPresent"` | The logic of image pulling |
+| image.repository | string | `"ghcr.io/koliver94/bss-request-manager"` | The Docker repository to pull the image from |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | Image pull secrets for the (private) container registry |
+| ingress.annotations | object | `{}` | Additional ingress annotations |
+| ingress.className | string | `""` | Defines which ingress controller will implement the resource |
+| ingress.enabled | bool | `false` | Enable an ingress resource for the server Service |
+| ingress.hosts | list | `[]` | List of ingress hosts |
+| ingress.tls | list | `[]` | Ingress TLS configuration |
+| initContainers | list | `[]` | Init containers to add to every deployment |
+| migrations.activeDeadlineSeconds | string | `""` | Hard time limit for the migration Job. Unset so a long migration is never killed midway. |
+| migrations.args | list | `["python","manage.py","migrate"]` | Container args for the migration Job |
+| migrations.backoffLimit | int | `3` | Number of retries before the migration Job is marked failed |
+| migrations.enabled | bool | `true` | Run database migrations from a dedicated Job on install and upgrade. One pod migrates, so the server can scale past a single replica. Disable to migrate out-of-band; the chart assumes it is the only migrator, `manage.py migrate` is not locked. |
+| migrations.resources.limits.cpu | string | `"500m"` | The maximum amount of CPU the container can use |
+| migrations.resources.limits.memory | string | `"512Mi"` | The maximum amount of memory the container can use |
+| migrations.resources.requests.cpu | string | `"100m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| migrations.resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| migrations.ttlSecondsAfterFinished | int | `600` | How long a finished migration Job is retained before automatic cleanup |
+| migrations.waitForMigrations | bool | `true` | Block every pod in an initContainer until migrations are applied. Deliberately not in the readiness probe: that would flip healthy running pods to NotReady whenever new migrations ship. |
+| migrations.waitTimeout | int | `300` | Seconds the initContainer waits for migrations before failing (the pod then retries) |
+| nameOverride | string | `""` | Provide a name in place of `request-manager` |
+| nodeSelector | object | `{}` | NodeSelector for all workloads |
+| podAnnotations | object | `{}` | Optional additional annotations to add to all pods |
+| podLabels | object | `{}` | Optional additional labels to add to all pods |
+| podSecurityContext | object | `{}` | Pod-level security context, merged over chart defaults (fsGroup 65532 for volume writes) |
+| postgres.auth.database | string | `"request_manager_db"` | Name for a custom database to create (also used as DATABASE_NAME) |
+| postgres.auth.password | string | `""` | Password for the custom user (also used as DATABASE_PASSWORD). Must be set. |
+| postgres.auth.username | string | `"request_manager"` | Name for a custom user to create (also used as DATABASE_USER) |
+| postgres.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
+| postgres.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |
+| postgres.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Use the container runtime default seccomp profile |
+| postgres.enabled | bool | `true` | Enable the CloudPirates PostgreSQL chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres> for possible values. |
+| postgres.resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
+| postgres.resources.limits.memory | string | `"1Gi"` | The maximum amount of memory the container can use |
+| postgres.resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| postgres.resources.requests.memory | string | `"256Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| redis.auth.enabled | bool | `false` | Enable password authentication |
+| redis.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
+| redis.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |
+| redis.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Use the container runtime default seccomp profile |
+| redis.enabled | bool | `true` | Enable the CloudPirates Redis® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis> for possible values. |
+| redis.resources.limits.cpu | string | `"150m"` | The maximum amount of CPU the container can use |
+| redis.resources.limits.memory | string | `"256Mi"` | The maximum amount of memory the container can use |
+| redis.resources.requests.cpu | string | `"50m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| redis.resources.requests.memory | string | `"128Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| secrets | object | `{"APP_SECRET_KEY":""}` | Sensitive environment variables rendered into a Secret, shared by all roles. Keys are the literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>. With postgres.enabled, DATABASE_PASSWORD defaults to postgres.auth.password. |
+| secrets.APP_SECRET_KEY | string | `""` | Django secret key. Generate with `openssl rand -base64 48`. |
+| securityContext | object | `{}` | Container-level security context, merged over the hardened chart defaults |
+| server.args | list | `["gunicorn","--bind=0.0.0.0:8000","--workers=2","--threads=4","--timeout=60","--graceful-timeout=30","--max-requests=1000","--max-requests-jitter=100","core.wsgi"]` | Container args (passed to the image entrypoint). Overrides the default Gunicorn command. |
+| server.autoscaling.enabled | bool | `false` | Controls whether autoscaling is enabled for the server deployment |
+| server.autoscaling.maxReplicas | int | `10` | Maximum number of server replicas |
+| server.autoscaling.minReplicas | int | `1` | Minimum number of server replicas |
+| server.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage that triggers scaling |
+| server.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":"http"},"initialDelaySeconds":10,"periodSeconds":10}` | Liveness probe for the server container |
+| server.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the server deployment |
+| server.pdb.maxUnavailable | string | `""` | Maximum unavailable server pods (takes precedence over minAvailable when set) |
+| server.pdb.minAvailable | string | `""` | Minimum available server pods (used when maxUnavailable is unset; defaults to 1) |
+| server.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":10,"periodSeconds":10}` | Readiness probe for the server container |
+| server.replicaCount | int | `1` | Number of Gunicorn server replicas (ignored when autoscaling is enabled) |
+| server.resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
+| server.resources.limits.memory | string | `"768Mi"` | The maximum amount of memory the container can use. Memory is incompressible, so this matches the request to keep the pod out of the early-eviction path. |
+| server.resources.requests.cpu | string | `"500m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| server.resources.requests.memory | string | `"768Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| server.service.port | int | `8000` | Port number for HTTP traffic (the container listens on this port too) |
+| server.service.type | string | `"ClusterIP"` | Kubernetes service type for HTTP traffic |
+| server.startupProbe | object | `{"failureThreshold":30,"httpGet":{"path":"/livez","port":"http"},"initialDelaySeconds":10,"periodSeconds":10}` | Startup probe for the server container |
+| server.strategy | object | `{}` | Deployment update strategy for the server workload |
+| server.terminationGracePeriodSeconds | int | `30` | Grace period for the server pod to finish in-flight requests on shutdown |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| tolerations | list | `[]` | Tolerations for all workloads |
+| worker.args | list | `["celery","-A","core","worker","--concurrency=2"]` | Container args for the Celery worker. Keep `--concurrency` in step with the CPU limit; without it Celery forks one process per node CPU, which will not fit the memory limit. |
+| worker.autoscaling.enabled | bool | `false` | Controls whether autoscaling is enabled for the worker deployment |
+| worker.autoscaling.maxReplicas | int | `10` | Maximum number of worker replicas |
+| worker.autoscaling.minReplicas | int | `1` | Minimum number of worker replicas |
+| worker.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage that triggers scaling |
+| worker.livenessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$HOSTNAME"]},"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":30,"timeoutSeconds":10}` | Liveness probe for the worker container |
+| worker.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the worker deployment |
+| worker.pdb.maxUnavailable | string | `""` | Maximum unavailable worker pods (takes precedence over minAvailable when set) |
+| worker.pdb.minAvailable | string | `""` | Minimum available worker pods (used when maxUnavailable is unset; defaults to 1) |
+| worker.readinessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$HOSTNAME"]},"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":30,"timeoutSeconds":10}` | Readiness probe for the worker container |
+| worker.replicaCount | int | `1` | Number of Celery worker replicas (ignored when autoscaling is enabled) |
+| worker.resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
+| worker.resources.limits.memory | string | `"768Mi"` | The maximum amount of memory the container can use |
+| worker.resources.requests.cpu | string | `"500m"` | Specifies the minimum amount of CPU that will be allocated to the container |
+| worker.resources.requests.memory | string | `"768Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| worker.terminationGracePeriodSeconds | int | `60` | Grace period for the worker to finish in-flight tasks on shutdown |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -128,11 +128,11 @@ Kubernetes: `>=1.23.0-0`
 | worker.autoscaling.maxReplicas | int | `10` | Maximum number of worker replicas |
 | worker.autoscaling.minReplicas | int | `1` | Minimum number of worker replicas |
 | worker.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage that triggers scaling |
-| worker.livenessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$HOSTNAME"]},"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":30,"timeoutSeconds":10}` | Liveness probe for the worker container |
+| worker.livenessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$(hostname)"]},"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":30,"timeoutSeconds":10}` | Liveness probe for the worker container |
 | worker.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the worker deployment |
 | worker.pdb.maxUnavailable | string | `""` | Maximum unavailable worker pods (takes precedence over minAvailable when set) |
 | worker.pdb.minAvailable | string | `""` | Minimum available worker pods (used when maxUnavailable is unset; defaults to 1) |
-| worker.readinessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$HOSTNAME"]},"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":30,"timeoutSeconds":10}` | Readiness probe for the worker container |
+| worker.readinessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$(hostname)"]},"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":30,"timeoutSeconds":10}` | Readiness probe for the worker container |
 | worker.replicaCount | int | `1` | Number of Celery worker replicas (ignored when autoscaling is enabled) |
 | worker.resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
 | worker.resources.limits.memory | string | `"768Mi"` | The maximum amount of memory the container can use |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -19,7 +19,7 @@ Manage video shooting and live streaming requests at Budavári Schönherz Stúdi
 
 ## Requirements
 
-Kubernetes: `>=1.19.0-0`
+Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/request-manager/ci/default-values.yaml
+++ b/charts/request-manager/ci/default-values.yaml
@@ -1,4 +1,7 @@
 ---
+# Deliberately no config.ALLOWED_HOSTS: this exercises the hosts the chart sets on its own
+# (pod IP for the probes, Service name for `helm test`).
+
 secrets:
   APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
 

--- a/charts/request-manager/ci/default-values.yaml
+++ b/charts/request-manager/ci/default-values.yaml
@@ -1,7 +1,4 @@
 ---
-config:
-  ALLOWED_HOSTS: "*"
-
 secrets:
   APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
 

--- a/charts/request-manager/ci/default-values.yaml
+++ b/charts/request-manager/ci/default-values.yaml
@@ -1,9 +1,22 @@
 ---
 # Deliberately no config.ALLOWED_HOSTS: this exercises the hosts the chart sets on its own
 # (pod IP for the probes, Service name for `helm test`).
+#
+# Everything else here is required by core.settings.production, which reads it with no fallback.
+
+config:
+  EMAIL_HOST: localhost
+  EMAIL_PORT: "25"
+  DEFAULT_FROM_EMAIL: noreply@example.com
+  DEFAULT_REPLY_EMAIL: reply@example.com
+  WEEKLY_TASK_EMAIL: weekly@example.com
+  GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME: ci-only-service-account.json
+  GOOGLE_CALENDAR_ID: ci-only@group.calendar.google.com
 
 secrets:
   APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+  SCH_EVENTS_TOKEN: ci-only-sch-events-token
+  SENTRY_URL: https://ci@ci.invalid/1
 
 postgres:
   auth:

--- a/charts/request-manager/ci/default-values.yaml
+++ b/charts/request-manager/ci/default-values.yaml
@@ -1,0 +1,10 @@
+---
+config:
+  ALLOWED_HOSTS: "*"
+
+secrets:
+  APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+
+postgres:
+  auth:
+    password: ci-only-postgres-password

--- a/charts/request-manager/ci/fullname-override-values.yaml
+++ b/charts/request-manager/ci/fullname-override-values.yaml
@@ -5,8 +5,19 @@
 
 fullnameOverride: video-requests
 
+config:
+  EMAIL_HOST: localhost
+  EMAIL_PORT: "25"
+  DEFAULT_FROM_EMAIL: noreply@example.com
+  DEFAULT_REPLY_EMAIL: reply@example.com
+  WEEKLY_TASK_EMAIL: weekly@example.com
+  GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME: ci-only-service-account.json
+  GOOGLE_CALENDAR_ID: ci-only@group.calendar.google.com
+
 secrets:
   APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+  SCH_EVENTS_TOKEN: ci-only-sch-events-token
+  SENTRY_URL: https://ci@ci.invalid/1
 
 postgres:
   auth:

--- a/charts/request-manager/ci/fullname-override-values.yaml
+++ b/charts/request-manager/ci/fullname-override-values.yaml
@@ -1,0 +1,13 @@
+---
+# Drives `request-manager.fullname` away from the release name, which the bundled sub-charts are
+# named after. `ct` always generates a release name containing the chart name, so this needs an
+# explicit override.
+
+fullnameOverride: video-requests
+
+secrets:
+  APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+
+postgres:
+  auth:
+    password: ci-only-postgres-password

--- a/charts/request-manager/ci/ingress-values.yaml
+++ b/charts/request-manager/ci/ingress-values.yaml
@@ -4,9 +4,18 @@
 
 config:
   ALLOWED_HOSTS: request.example.com
+  EMAIL_HOST: localhost
+  EMAIL_PORT: "25"
+  DEFAULT_FROM_EMAIL: noreply@example.com
+  DEFAULT_REPLY_EMAIL: reply@example.com
+  WEEKLY_TASK_EMAIL: weekly@example.com
+  GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME: ci-only-service-account.json
+  GOOGLE_CALENDAR_ID: ci-only@group.calendar.google.com
 
 secrets:
   APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+  SCH_EVENTS_TOKEN: ci-only-sch-events-token
+  SENTRY_URL: https://ci@ci.invalid/1
 
 postgres:
   auth:

--- a/charts/request-manager/ci/ingress-values.yaml
+++ b/charts/request-manager/ci/ingress-values.yaml
@@ -1,0 +1,20 @@
+---
+# Ingress enabled with a realistic ALLOWED_HOSTS, and pathType omitted so the chart default is
+# what the API server validates.
+
+config:
+  ALLOWED_HOSTS: request.example.com
+
+secrets:
+  APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+
+postgres:
+  auth:
+    password: ci-only-postgres-password
+
+ingress:
+  enabled: true
+  hosts:
+    - host: request.example.com
+      paths:
+        - path: /

--- a/charts/request-manager/ci/security-overrides-values.yaml
+++ b/charts/request-manager/ci/security-overrides-values.yaml
@@ -2,8 +2,19 @@
 # Exercises the security context merge helpers. Both keys below differ from the chart defaults, so
 # a merge that silently drops user input fails here rather than rendering something plausible.
 
+config:
+  EMAIL_HOST: localhost
+  EMAIL_PORT: "25"
+  DEFAULT_FROM_EMAIL: noreply@example.com
+  DEFAULT_REPLY_EMAIL: reply@example.com
+  WEEKLY_TASK_EMAIL: weekly@example.com
+  GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME: ci-only-service-account.json
+  GOOGLE_CALENDAR_ID: ci-only@group.calendar.google.com
+
 secrets:
   APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+  SCH_EVENTS_TOKEN: ci-only-sch-events-token
+  SENTRY_URL: https://ci@ci.invalid/1
 
 postgres:
   auth:

--- a/charts/request-manager/ci/security-overrides-values.yaml
+++ b/charts/request-manager/ci/security-overrides-values.yaml
@@ -1,0 +1,19 @@
+---
+# Exercises the security context merge helpers. Both keys below differ from the chart defaults, so
+# a merge that silently drops user input fails here rather than rendering something plausible.
+
+secrets:
+  APP_SECRET_KEY: ci-only-not-a-real-secret-key-do-not-reuse
+
+postgres:
+  auth:
+    password: ci-only-postgres-password
+
+# Nested merge: `add` must apply without losing the default `drop: [ALL]`.
+securityContext:
+  capabilities:
+    add:
+      - NET_BIND_SERVICE
+
+podSecurityContext:
+  fsGroupChangePolicy: Always

--- a/charts/request-manager/templates/NOTES.txt
+++ b/charts/request-manager/templates/NOTES.txt
@@ -1,0 +1,40 @@
+{{- $fullName := include "request-manager.fullname" . -}}
+BSS Request Manager {{ .Chart.AppVersion }} has been deployed as release {{ .Release.Name }}.
+
+Workloads:
+  - {{ $fullName }}-server  (Gunicorn web/API)
+  - {{ $fullName }}-worker  (Celery worker)
+  - {{ $fullName }}-beat    (Celery beat scheduler)
+{{- if .Values.migrations.enabled }}
+  - {{ $fullName }}-migrate-{{ .Release.Revision }} (database migrations; runs on install and upgrade)
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+Reach the application at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else }}
+
+The web service is exposed on a {{ .Values.server.service.type }} Service. To reach it locally:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ $fullName }} {{ .Values.server.service.port }}:{{ .Values.server.service.port }}
+
+then open http://127.0.0.1:{{ .Values.server.service.port }}
+{{- end }}
+
+{{- if not .Values.existingSecret }}
+{{- if not (index .Values.secrets "APP_SECRET_KEY") }}
+
+WARNING: secrets.APP_SECRET_KEY is empty. Production requires it and the pods will fail to
+start without it. Set it (e.g. `openssl rand -base64 48`).
+{{- end }}
+{{- if and .Values.postgres.enabled (not .Values.postgres.auth.password) (not (index .Values.secrets "DATABASE_PASSWORD")) }}
+
+WARNING: postgres.auth.password is empty. Set it so the app and the bundled PostgreSQL
+agree on the database password.
+{{- end }}
+{{- end }}

--- a/charts/request-manager/templates/NOTES.txt
+++ b/charts/request-manager/templates/NOTES.txt
@@ -26,15 +26,13 @@ The web service is exposed on a {{ .Values.server.service.type }} Service. To re
 then open http://127.0.0.1:{{ .Values.server.service.port }}
 {{- end }}
 
-{{- if not .Values.existingSecret }}
-{{- if not (index .Values.secrets "APP_SECRET_KEY") }}
+{{- if and (not .Values.existingSecret) (not (index .Values.secrets "APP_SECRET_KEY")) }}
 
 WARNING: secrets.APP_SECRET_KEY is empty. Production requires it and the pods will fail to
 start without it. Set it (e.g. `openssl rand -base64 48`).
 {{- end }}
-{{- if and .Values.postgres.enabled (not .Values.postgres.auth.password) (not (index .Values.secrets "DATABASE_PASSWORD")) }}
+{{- if and .Values.postgres.enabled (not .Values.postgres.auth.password) }}
 
 WARNING: postgres.auth.password is empty. Set it so the app and the bundled PostgreSQL
 agree on the database password.
-{{- end }}
 {{- end }}

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -103,10 +103,7 @@ exits non-zero while any are pending, so every pod can run it concurrently.
       'until python manage.py migrate --check; do
       echo "waiting for migrations..."; sleep 5; done'
   env:
-    - name: DJANGO_CONTAINER
-      value: "false"
-    - name: HOME
-      value: /tmp
+    {{- include "request-manager.env" . | nindent 4 }}
   envFrom:
     {{- include "request-manager.envFrom" . | nindent 4 }}
   resources:
@@ -140,6 +137,7 @@ Non-secret connection defaults derived from the bundled sub-charts. User supplie
 
 {{/*
 The merged, non-secret configuration map (computed defaults + user overrides).
+ALLOWED_HOSTS is excluded; "request-manager.env" renders it instead.
 */}}
 {{- define "request-manager.config" -}}
 {{- $computed := fromYaml (include "request-manager.computedConfig" .) -}}
@@ -147,7 +145,25 @@ The merged, non-secret configuration map (computed defaults + user overrides).
 {{- range $k, $v := .Values.config -}}
 {{- $_ := set $user $k ($v | toString) -}}
 {{- end -}}
-{{- merge $user $computed | toYaml -}}
+{{- merge (omit $user "ALLOWED_HOSTS") $computed | toYaml -}}
+{{- end }}
+
+{{/*
+Environment variables shared by every application container.
+ALLOWED_HOSTS lives here, not in the ConfigMap, so it can pick up the pod IP: probes carry it as
+the Host header and Django 400s any host it does not list. The Service name covers `helm test`.
+*/}}
+{{- define "request-manager.env" -}}
+- name: DJANGO_CONTAINER
+  value: "false"
+- name: HOME
+  value: /tmp
+- name: POD_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.podIP
+- name: ALLOWED_HOSTS
+  value: "$(POD_IP),127.0.0.1,localhost,{{ include "request-manager.fullname" . }}{{ with (default dict .Values.config).ALLOWED_HOSTS }},{{ . }}{{ end }}"
 {{- end }}
 
 {{/*

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -158,16 +158,26 @@ Non-secret connection defaults derived from the bundled sub-charts. User supplie
 {{- end }}
 
 {{/*
-The merged, non-secret configuration map (computed defaults + user overrides).
+The merged, non-secret configuration (computed defaults + user overrides). Empty values are dropped
+so that blanking a default in a values file removes the variable rather than setting it to "".
 ALLOWED_HOSTS is excluded; "request-manager.env" renders it instead.
 */}}
 {{- define "request-manager.config" -}}
 {{- $computed := fromYaml (include "request-manager.computedConfig" .) -}}
 {{- $user := dict -}}
-{{- range $k, $v := .Values.config -}}
-{{- $_ := set $user $k ($v | toString) -}}
+{{- range $k, $v := omit .Values.config "ALLOWED_HOSTS" -}}
+{{- if not (kindIs "invalid" $v) -}}
+{{- $rendered := tpl ($v | toString) $ -}}
+{{- if $rendered -}}
+{{- $_ := set $user $k $rendered -}}
 {{- end -}}
-{{- merge (omit $user "ALLOWED_HOSTS") $computed | toYaml -}}
+{{- end -}}
+{{- end -}}
+{{- range $k, $v := merge $user $computed }}
+{{- if $v }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -1,0 +1,228 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "request-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "request-manager.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "request-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "request-manager.labels" -}}
+helm.sh/chart: {{ include "request-manager.chart" . }}
+{{ include "request-manager.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ include "request-manager.name" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "request-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "request-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "request-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "request-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret that holds the application's sensitive environment variables.
+Uses an externally provided Secret when `existingSecret` is set.
+*/}}
+{{- define "request-manager.secretName" -}}
+{{- if .Values.existingSecret }}
+{{- .Values.existingSecret }}
+{{- else }}
+{{- include "request-manager.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret that holds the Google service account key file.
+*/}}
+{{- define "request-manager.credentialsSecretName" -}}
+{{- if .Values.credentials.existingSecret }}
+{{- .Values.credentials.existingSecret }}
+{{- else }}
+{{- printf "%s-credentials" (include "request-manager.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+initContainer that blocks until migrations are applied. `migrate --check` applies nothing and
+exits non-zero while any are pending, so every pod can run it concurrently.
+*/}}
+{{- define "request-manager.waitForMigrationsInitContainer" -}}
+- name: wait-for-migrations
+  securityContext:
+    {{- include "request-manager.containerSecurityContext" . | nindent 4 }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+  args:
+    - sh
+    - -c
+    - >-
+      timeout {{ .Values.migrations.waitTimeout }} sh -c
+      'until python manage.py migrate --check; do
+      echo "waiting for migrations..."; sleep 5; done'
+  env:
+    - name: DJANGO_CONTAINER
+      value: "false"
+    - name: HOME
+      value: /tmp
+  envFrom:
+    {{- include "request-manager.envFrom" . | nindent 4 }}
+  resources:
+    {{- toYaml .Values.migrations.resources | nindent 4 }}
+  volumeMounts:
+    {{- include "request-manager.volumeMounts" . | nindent 4 }}
+{{- end }}
+
+{{/*
+Non-secret connection defaults derived from the bundled sub-charts. User supplied
+`.Values.config` keys win over these computed defaults.
+*/}}
+{{- define "request-manager.computedConfig" -}}
+{{- $cfg := dict -}}
+{{- if .Values.postgres.enabled -}}
+{{- $_ := set $cfg "DATABASE_HOST" (printf "%s-postgres" .Release.Name) -}}
+{{- $_ := set $cfg "DATABASE_PORT" "5432" -}}
+{{- $_ := set $cfg "DATABASE_NAME" (.Values.postgres.auth.database | toString) -}}
+{{- $_ := set $cfg "DATABASE_USER" (.Values.postgres.auth.username | toString) -}}
+{{- end -}}
+{{- if .Values.redis.enabled -}}
+{{- $host := printf "%s-redis" .Release.Name -}}
+{{- $_ := set $cfg "CACHE_REDIS" (printf "redis://%s:6379/0" $host) -}}
+{{- $_ := set $cfg "CELERY_BROKER" (printf "redis://%s:6379/1" $host) -}}
+{{- end -}}
+{{- if .Values.credentials.enabled -}}
+{{- $_ := set $cfg "GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME" (.Values.credentials.fileName | toString) -}}
+{{- end -}}
+{{- $cfg | toYaml -}}
+{{- end }}
+
+{{/*
+The merged, non-secret configuration map (computed defaults + user overrides).
+*/}}
+{{- define "request-manager.config" -}}
+{{- $computed := fromYaml (include "request-manager.computedConfig" .) -}}
+{{- $user := dict -}}
+{{- range $k, $v := .Values.config -}}
+{{- $_ := set $user $k ($v | toString) -}}
+{{- end -}}
+{{- merge $user $computed | toYaml -}}
+{{- end }}
+
+{{/*
+envFrom sources shared by every application container.
+*/}}
+{{- define "request-manager.envFrom" -}}
+- configMapRef:
+    name: {{ include "request-manager.fullname" . }}
+- secretRef:
+    name: {{ include "request-manager.secretName" . }}
+{{- with .Values.extraEnvFrom }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Volumes shared by every application container. `/tmp` must be writable because the root
+filesystem is read-only.
+*/}}
+{{- define "request-manager.volumes" -}}
+- name: tmp
+  emptyDir:
+    medium: Memory
+{{- if .Values.credentials.enabled }}
+- name: credentials
+  secret:
+    secretName: {{ include "request-manager.credentialsSecretName" . }}
+{{- end }}
+{{- with .Values.extraVolumes }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Volume mounts shared by every application container.
+*/}}
+{{- define "request-manager.volumeMounts" -}}
+- name: tmp
+  mountPath: /tmp
+{{- if .Values.credentials.enabled }}
+- name: credentials
+  mountPath: /app/backend/credentials
+  readOnly: true
+{{- end }}
+{{- with .Values.extraVolumeMounts }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container-level security context shared by every application container.
+*/}}
+{{- define "request-manager.containerSecurityContext" -}}
+runAsUser: 65532
+runAsGroup: 65532
+allowPrivilegeEscalation: false
+runAsNonRoot: true
+readOnlyRootFilesystem: true
+capabilities:
+  drop:
+    - ALL
+{{- with .Values.securityContext }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod-level security context shared by every pod.
+*/}}
+{{- define "request-manager.podSecurityContext" -}}
+seccompProfile:
+  type: RuntimeDefault
+fsGroup: 65532
+fsGroupChangePolicy: OnRootMismatch
+{{- with .Values.podSecurityContext }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -215,30 +215,28 @@ Volume mounts shared by every application container.
 
 {{/*
 Container-level security context shared by every application container.
+Merged as a dict so user keys override the defaults instead of being appended as duplicates.
 */}}
 {{- define "request-manager.containerSecurityContext" -}}
-runAsUser: 65532
-runAsGroup: 65532
-allowPrivilegeEscalation: false
-runAsNonRoot: true
-readOnlyRootFilesystem: true
-capabilities:
-  drop:
-    - ALL
-{{- with .Values.securityContext }}
-{{- toYaml . }}
-{{- end }}
+{{- $defaults := dict
+  "runAsUser" 65532
+  "runAsGroup" 65532
+  "allowPrivilegeEscalation" false
+  "runAsNonRoot" true
+  "readOnlyRootFilesystem" true
+  "capabilities" (dict "drop" (list "ALL"))
+-}}
+{{- toYaml (mustMergeOverwrite $defaults (deepCopy (default dict .Values.securityContext))) }}
 {{- end }}
 
 {{/*
 Pod-level security context shared by every pod.
 */}}
 {{- define "request-manager.podSecurityContext" -}}
-seccompProfile:
-  type: RuntimeDefault
-fsGroup: 65532
-fsGroupChangePolicy: OnRootMismatch
-{{- with .Values.podSecurityContext }}
-{{- toYaml . }}
-{{- end }}
+{{- $defaults := dict
+  "seccompProfile" (dict "type" "RuntimeDefault")
+  "fsGroup" 65532
+  "fsGroupChangePolicy" "OnRootMismatch"
+-}}
+{{- toYaml (mustMergeOverwrite $defaults (deepCopy (default dict .Values.podSecurityContext))) }}
 {{- end }}

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -186,6 +186,9 @@ the Host header and Django 400s any host it does not list. The Service name cove
       fieldPath: status.podIP
 - name: ALLOWED_HOSTS
   value: "$(POD_IP),127.0.0.1,localhost,{{ include "request-manager.fullname" . }}{{ with (default dict .Values.config).ALLOWED_HOSTS }},{{ . }}{{ end }}"
+{{- with .Values.extraEnv }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -86,6 +86,17 @@ Name of the Secret that holds the Google service account key file.
 {{- end }}
 
 {{/*
+Whether pods block until migrations are applied. Unset follows migrations.enabled.
+*/}}
+{{- define "request-manager.waitForMigrations" -}}
+{{- if kindIs "invalid" .Values.migrations.waitForMigrations -}}
+{{- .Values.migrations.enabled -}}
+{{- else -}}
+{{- .Values.migrations.waitForMigrations -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 initContainer that blocks until migrations are applied. `migrate --check` applies nothing and
 exits non-zero while any are pending, so every pod can run it concurrently.
 */}}

--- a/charts/request-manager/templates/_helpers.tpl
+++ b/charts/request-manager/templates/_helpers.tpl
@@ -63,14 +63,25 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Name of the Secret that holds the application's sensitive environment variables.
-Uses an externally provided Secret when `existingSecret` is set.
+The application's sensitive environment variables. DATABASE_PASSWORD is derived from
+`postgres.auth` so the bundled sub-chart stays the single source of truth for it; that stays true
+under `existingSecret`, which replaces only the user-supplied `secrets`.
 */}}
-{{- define "request-manager.secretName" -}}
-{{- if .Values.existingSecret }}
-{{- .Values.existingSecret }}
-{{- else }}
-{{- include "request-manager.fullname" . }}
+{{- define "request-manager.secrets" -}}
+{{- $computed := dict -}}
+{{- if and .Values.postgres.enabled .Values.postgres.auth.password -}}
+{{- $_ := set $computed "DATABASE_PASSWORD" .Values.postgres.auth.password -}}
+{{- end -}}
+{{- $user := dict -}}
+{{- if not .Values.existingSecret -}}
+{{- range $k, $v := .Values.secrets -}}
+{{- if and (not (kindIs "invalid" $v)) (ne ($v | toString) "") -}}
+{{- $_ := set $user $k ($v | toString) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- range $k, $v := merge $user $computed }}
+{{ $k }}: {{ $v | b64enc | quote }}
 {{- end }}
 {{- end }}
 
@@ -184,7 +195,11 @@ envFrom sources shared by every application container.
 - configMapRef:
     name: {{ include "request-manager.fullname" . }}
 - secretRef:
-    name: {{ include "request-manager.secretName" . }}
+    name: {{ include "request-manager.fullname" . }}
+{{- with .Values.existingSecret }}
+- secretRef:
+    name: {{ . }}
+{{- end }}
 {{- with .Values.extraEnvFrom }}
 {{- toYaml . }}
 {{- end }}

--- a/charts/request-manager/templates/beat/deployment.yaml
+++ b/charts/request-manager/templates/beat/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "request-manager.fullname" . }}-beat
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: beat
+  annotations:
+    checkov.io/skip1: CKV_K8S_8=Single scheduler process with no HTTP surface; a hang is not observable without app support, and on exit the container is restarted
+    checkov.io/skip2: CKV_K8S_9=No Service selects beat, so readiness has no consumer
+spec:
+  # A single beat scheduler must run at a time; Recreate avoids two schedulers overlapping
+  # during a rollout and double-firing periodic tasks.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "request-manager.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: beat
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "request-manager.labels" . | nindent 8 }}
+        app.kubernetes.io/component: beat
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "request-manager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.beat.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- include "request-manager.podSecurityContext" . | nindent 8 }}
+      {{- if or .Values.migrations.waitForMigrations .Values.initContainers }}
+      initContainers:
+        {{- if .Values.migrations.waitForMigrations }}
+        {{- include "request-manager.waitForMigrationsInitContainer" . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: beat
+          securityContext:
+            {{- include "request-manager.containerSecurityContext" . | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
+            {{- toYaml .Values.beat.args | nindent 12 }}
+          env:
+            - name: DJANGO_CONTAINER
+              value: "false"
+            - name: HOME
+              value: /tmp
+          envFrom:
+            {{- include "request-manager.envFrom" . | nindent 12 }}
+          {{- with .Values.beat.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.beat.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "request-manager.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "request-manager.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/request-manager/templates/beat/deployment.yaml
+++ b/charts/request-manager/templates/beat/deployment.yaml
@@ -62,10 +62,7 @@ spec:
           args:
             {{- toYaml .Values.beat.args | nindent 12 }}
           env:
-            - name: DJANGO_CONTAINER
-              value: "false"
-            - name: HOME
-              value: /tmp
+            {{- include "request-manager.env" . | nindent 12 }}
           envFrom:
             {{- include "request-manager.envFrom" . | nindent 12 }}
           {{- with .Values.beat.livenessProbe }}

--- a/charts/request-manager/templates/beat/deployment.yaml
+++ b/charts/request-manager/templates/beat/deployment.yaml
@@ -44,9 +44,9 @@ spec:
       {{- end }}
       securityContext:
         {{- include "request-manager.podSecurityContext" . | nindent 8 }}
-      {{- if or .Values.migrations.waitForMigrations .Values.initContainers }}
+      {{- if or (eq (include "request-manager.waitForMigrations" .) "true") .Values.initContainers }}
       initContainers:
-        {{- if .Values.migrations.waitForMigrations }}
+        {{- if eq (include "request-manager.waitForMigrations" .) "true" }}
         {{- include "request-manager.waitForMigrationsInitContainer" . | nindent 8 }}
         {{- end }}
         {{- with .Values.initContainers }}

--- a/charts/request-manager/templates/configmap.yaml
+++ b/charts/request-manager/templates/configmap.yaml
@@ -5,7 +5,4 @@ metadata:
   labels:
     {{- include "request-manager.labels" . | nindent 4 }}
 data:
-  {{- $cfg := fromYaml (include "request-manager.config" .) }}
-  {{- range $k, $v := $cfg }}
-  {{ $k }}: {{ $v | quote }}
-  {{- end }}
+  {{- include "request-manager.config" . | trim | default "{}" | nindent 2 }}

--- a/charts/request-manager/templates/configmap.yaml
+++ b/charts/request-manager/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "request-manager.fullname" . }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+data:
+  {{- $cfg := fromYaml (include "request-manager.config" .) }}
+  {{- range $k, $v := $cfg }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/charts/request-manager/templates/credentials-secret.yaml
+++ b/charts/request-manager/templates/credentials-secret.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.credentials.enabled (not .Values.credentials.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "request-manager.credentialsSecretName" . }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.credentials.fileName }}: {{ required
+    "credentials.serviceAccountKey is required when credentials.enabled and no existingSecret is set"
+    .Values.credentials.serviceAccountKey | b64enc | quote }}
+{{- end }}

--- a/charts/request-manager/templates/migrate-job.yaml
+++ b/charts/request-manager/templates/migrate-job.yaml
@@ -50,10 +50,7 @@ spec:
           args:
             {{- toYaml .Values.migrations.args | nindent 12 }}
           env:
-            - name: DJANGO_CONTAINER
-              value: "false"
-            - name: HOME
-              value: /tmp
+            {{- include "request-manager.env" . | nindent 12 }}
           envFrom:
             {{- include "request-manager.envFrom" . | nindent 12 }}
           resources:

--- a/charts/request-manager/templates/migrate-job.yaml
+++ b/charts/request-manager/templates/migrate-job.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.migrations.enabled }}
+{{/*
+Not a Helm hook: pre-install runs before the bundled postgres exists, and post-install only runs
+after `--wait` sees pods ready. A plain resource is applied alongside the Deployments instead.
+The revision suffix keeps the immutable Job spec upgradeable; Helm prunes the previous one.
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-migrate-%d" (include "request-manager.fullname" .) .Release.Revision | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  {{- with .Values.migrations.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
+  {{- with .Values.migrations.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "request-manager.labels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "request-manager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      securityContext:
+        {{- include "request-manager.podSecurityContext" . | nindent 8 }}
+      containers:
+        - name: migrate
+          securityContext:
+            {{- include "request-manager.containerSecurityContext" . | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
+            {{- toYaml .Values.migrations.args | nindent 12 }}
+          env:
+            - name: DJANGO_CONTAINER
+              value: "false"
+            - name: HOME
+              value: /tmp
+          envFrom:
+            {{- include "request-manager.envFrom" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "request-manager.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "request-manager.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/request-manager/templates/secret.yaml
+++ b/charts/request-manager/templates/secret.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,13 +6,4 @@ metadata:
     {{- include "request-manager.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- $secrets := deepCopy .Values.secrets }}
-  {{- if and .Values.postgres.enabled (not (hasKey .Values.secrets "DATABASE_PASSWORD")) }}
-  {{- $_ := set $secrets "DATABASE_PASSWORD" .Values.postgres.auth.password }}
-  {{- end }}
-  {{- range $k, $v := $secrets }}
-  {{- if and (not (kindIs "invalid" $v)) (ne ($v | toString) "") }}
-  {{ $k }}: {{ $v | toString | b64enc | quote }}
-  {{- end }}
-  {{- end }}
-{{- end }}
+  {{- include "request-manager.secrets" . | trim | default "{}" | nindent 2 }}

--- a/charts/request-manager/templates/secret.yaml
+++ b/charts/request-manager/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "request-manager.fullname" . }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- $secrets := deepCopy .Values.secrets }}
+  {{- if and .Values.postgres.enabled (not (hasKey .Values.secrets "DATABASE_PASSWORD")) }}
+  {{- $_ := set $secrets "DATABASE_PASSWORD" .Values.postgres.auth.password }}
+  {{- end }}
+  {{- range $k, $v := $secrets }}
+  {{- if and (not (kindIs "invalid" $v)) (ne ($v | toString) "") }}
+  {{ $k }}: {{ $v | toString | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/request-manager/templates/server/deployment.yaml
+++ b/charts/request-manager/templates/server/deployment.yaml
@@ -61,10 +61,7 @@ spec:
           args:
             {{- toYaml .Values.server.args | nindent 12 }}
           env:
-            - name: DJANGO_CONTAINER
-              value: "false"
-            - name: HOME
-              value: /tmp
+            {{- include "request-manager.env" . | nindent 12 }}
           envFrom:
             {{- include "request-manager.envFrom" . | nindent 12 }}
           ports:

--- a/charts/request-manager/templates/server/deployment.yaml
+++ b/charts/request-manager/templates/server/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "request-manager.fullname" . }}-server
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  {{- if not .Values.server.autoscaling.enabled }}
+  replicas: {{ .Values.server.replicaCount }}
+  {{- end }}
+  {{- with .Values.server.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "request-manager.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "request-manager.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "request-manager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.server.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- include "request-manager.podSecurityContext" . | nindent 8 }}
+      {{- if or .Values.migrations.waitForMigrations .Values.initContainers }}
+      initContainers:
+        {{- if .Values.migrations.waitForMigrations }}
+        {{- include "request-manager.waitForMigrationsInitContainer" . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: server
+          securityContext:
+            {{- include "request-manager.containerSecurityContext" . | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
+            {{- toYaml .Values.server.args | nindent 12 }}
+          env:
+            - name: DJANGO_CONTAINER
+              value: "false"
+            - name: HOME
+              value: /tmp
+          envFrom:
+            {{- include "request-manager.envFrom" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.service.port }}
+              protocol: TCP
+          {{- with .Values.server.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "request-manager.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "request-manager.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/request-manager/templates/server/deployment.yaml
+++ b/charts/request-manager/templates/server/deployment.yaml
@@ -43,9 +43,9 @@ spec:
       {{- end }}
       securityContext:
         {{- include "request-manager.podSecurityContext" . | nindent 8 }}
-      {{- if or .Values.migrations.waitForMigrations .Values.initContainers }}
+      {{- if or (eq (include "request-manager.waitForMigrations" .) "true") .Values.initContainers }}
       initContainers:
-        {{- if .Values.migrations.waitForMigrations }}
+        {{- if eq (include "request-manager.waitForMigrations" .) "true" }}
         {{- include "request-manager.waitForMigrationsInitContainer" . | nindent 8 }}
         {{- end }}
         {{- with .Values.initContainers }}

--- a/charts/request-manager/templates/server/hpa.yaml
+++ b/charts/request-manager/templates/server/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.server.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "request-manager.fullname" . }}-server
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "request-manager.fullname" . }}-server
+  minReplicas: {{ .Values.server.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/request-manager/templates/server/ingress.yaml
+++ b/charts/request-manager/templates/server/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "request-manager.fullname" . -}}
+{{- $svcPort := .Values.server.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/request-manager/templates/server/ingress.yaml
+++ b/charts/request-manager/templates/server/ingress.yaml
@@ -33,9 +33,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/request-manager/templates/server/pdb.yaml
+++ b/charts/request-manager/templates/server/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.server.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "request-manager.fullname" . }}-server
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  {{- if .Values.server.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.server.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.server.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "request-manager.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+{{- end }}

--- a/charts/request-manager/templates/server/service.yaml
+++ b/charts/request-manager/templates/server/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "request-manager.fullname" . }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: {{ .Values.server.service.type }}
+  ports:
+    - port: {{ .Values.server.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "request-manager.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/charts/request-manager/templates/serviceaccount.yaml
+++ b/charts/request-manager/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "request-manager.serviceAccountName" . }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/request-manager/templates/tests/test-connection.yaml
+++ b/charts/request-manager/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- $url := printf "http://%s:%v" (include "request-manager.fullname" .) .Values.server.service.port -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -27,11 +28,12 @@ spec:
         capabilities:
           drop:
             - ALL
-      command: [wget]
+      command: [sh]
       args:
-        - --spider
-        - -S
-        - http://{{ include "request-manager.fullname" . }}:{{ .Values.server.service.port }}/livez
+        - -ec
+        - |
+          wget --spider -S {{ $url }}/livez
+          wget --spider -S {{ $url }}/readyz
       resources:
         requests:
           cpu: 50m

--- a/charts/request-manager/templates/tests/test-connection.yaml
+++ b/charts/request-manager/templates/tests/test-connection.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ printf "%s-test-connection" (include "request-manager.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    checkov.io/skip1: CKV_K8S_8=One-shot helm test pod runs to completion; liveness probe not applicable
+    checkov.io/skip2: CKV_K8S_9=One-shot helm test pod runs to completion; readiness probe not applicable
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: test-connection
+      image: busybox:stable-uclibc
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command: [wget]
+      args:
+        - --spider
+        - -S
+        - http://{{ include "request-manager.fullname" . }}:{{ .Values.server.service.port }}/livez
+      resources:
+        requests:
+          cpu: 50m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi

--- a/charts/request-manager/templates/worker/deployment.yaml
+++ b/charts/request-manager/templates/worker/deployment.yaml
@@ -39,9 +39,9 @@ spec:
       {{- end }}
       securityContext:
         {{- include "request-manager.podSecurityContext" . | nindent 8 }}
-      {{- if or .Values.migrations.waitForMigrations .Values.initContainers }}
+      {{- if or (eq (include "request-manager.waitForMigrations" .) "true") .Values.initContainers }}
       initContainers:
-        {{- if .Values.migrations.waitForMigrations }}
+        {{- if eq (include "request-manager.waitForMigrations" .) "true" }}
         {{- include "request-manager.waitForMigrationsInitContainer" . | nindent 8 }}
         {{- end }}
         {{- with .Values.initContainers }}

--- a/charts/request-manager/templates/worker/deployment.yaml
+++ b/charts/request-manager/templates/worker/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "request-manager.fullname" . }}-worker
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  {{- if not .Values.worker.autoscaling.enabled }}
+  replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "request-manager.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "request-manager.labels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "request-manager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.worker.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- include "request-manager.podSecurityContext" . | nindent 8 }}
+      {{- if or .Values.migrations.waitForMigrations .Values.initContainers }}
+      initContainers:
+        {{- if .Values.migrations.waitForMigrations }}
+        {{- include "request-manager.waitForMigrationsInitContainer" . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: worker
+          securityContext:
+            {{- include "request-manager.containerSecurityContext" . | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
+            {{- toYaml .Values.worker.args | nindent 12 }}
+          env:
+            - name: DJANGO_CONTAINER
+              value: "false"
+            - name: HOME
+              value: /tmp
+          envFrom:
+            {{- include "request-manager.envFrom" . | nindent 12 }}
+          {{- with .Values.worker.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          volumeMounts:
+            {{- include "request-manager.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "request-manager.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/request-manager/templates/worker/deployment.yaml
+++ b/charts/request-manager/templates/worker/deployment.yaml
@@ -57,10 +57,7 @@ spec:
           args:
             {{- toYaml .Values.worker.args | nindent 12 }}
           env:
-            - name: DJANGO_CONTAINER
-              value: "false"
-            - name: HOME
-              value: /tmp
+            {{- include "request-manager.env" . | nindent 12 }}
           envFrom:
             {{- include "request-manager.envFrom" . | nindent 12 }}
           {{- with .Values.worker.livenessProbe }}

--- a/charts/request-manager/templates/worker/hpa.yaml
+++ b/charts/request-manager/templates/worker/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.worker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "request-manager.fullname" . }}-worker
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "request-manager.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/request-manager/templates/worker/pdb.yaml
+++ b/charts/request-manager/templates/worker/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.worker.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "request-manager.fullname" . }}-worker
+  labels:
+    {{- include "request-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  {{- if .Values.worker.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.worker.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.worker.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "request-manager.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+{{- end }}

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -285,7 +285,7 @@ credentials:
   enabled: false
   # -- Use an existing Secret holding the key file instead of creating one from `serviceAccountKey`
   existingSecret: ""
-  # -- File name of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME)
+  # -- Filename of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME)
   fileName: service-account-key-file.json
   # -- Contents of the Google service account JSON key. Ignored when `existingSecret` is set.
   serviceAccountKey: ""

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -336,6 +336,14 @@ secrets:
 # keys must be the environment variable names. DATABASE_PASSWORD stays chart-managed.
 existingSecret: ""
 
+# -- Additional environment variables, appended to every container verbatim. Prefer `config` and
+# `secrets`; entries here take precedence over both.
+extraEnv: []
+  # - name: MY_SETTING
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: metadata.namespace
+
 # -- Additional envFrom sources appended to every container
 extraEnvFrom: []
   # - secretRef:

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -156,7 +156,7 @@ worker:
       command:
         - sh
         - -c
-        - celery -A core inspect ping -d celery@$HOSTNAME
+        - celery -A core inspect ping -d celery@$(hostname)
     initialDelaySeconds: 30
     periodSeconds: 30
     timeoutSeconds: 10
@@ -167,7 +167,7 @@ worker:
       command:
         - sh
         - -c
-        - celery -A core inspect ping -d celery@$HOSTNAME
+        - celery -A core inspect ping -d celery@$(hostname)
     initialDelaySeconds: 15
     periodSeconds: 30
     timeoutSeconds: 10

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -231,7 +231,9 @@ migrations:
   enabled: true
   # -- Block every pod in an initContainer until migrations are applied. Deliberately not in the
   # readiness probe: that would flip healthy running pods to NotReady whenever new migrations ship.
-  waitForMigrations: true
+  # Set explicitly to wait even when the Job is disabled; pods then block until you migrate.
+  # @default -- `migrations.enabled`
+  waitForMigrations: ~
   # -- Seconds the initContainer waits for migrations before failing (the pod then retries)
   waitTimeout: 300
   # -- Container args for the migration Job

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -332,8 +332,8 @@ secrets:
   # TURNSTILE_SECRET_KEY: ""
   # EMAIL_HOST_PASSWORD: ""
 
-# -- Supply the sensitive environment variables from an existing Secret instead of `secrets`.
-# The Secret's keys must match the expected environment variable names.
+# -- Supply the sensitive environment variables from an existing Secret instead of `secrets`. Its
+# keys must be the environment variable names. DATABASE_PASSWORD stays chart-managed.
 existingSecret: ""
 
 # -- Additional envFrom sources appended to every container

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -1,0 +1,411 @@
+---
+# -- Provide a name in place of `request-manager`
+nameOverride: ""
+# -- String to fully override `"request-manager.fullname"`
+fullnameOverride: ""
+
+image:
+  # -- The Docker repository to pull the image from
+  repository: ghcr.io/koliver94/bss-request-manager
+  # -- The logic of image pulling
+  imagePullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# -- Image pull secrets for the (private) container registry
+imagePullSecrets: []
+  # - name: ghcr-credentials
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Automatically mount a ServiceAccount's API credentials?
+  automount: false
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# -- Optional additional annotations to add to all pods
+podAnnotations: {}
+
+# -- Optional additional labels to add to all pods
+podLabels: {}
+
+# -- Pod-level security context, merged over chart defaults (fsGroup 65532 for volume writes)
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container-level security context, merged over the hardened chart defaults
+securityContext: {}
+  # runAsUser: 65532
+
+# -- Init containers to add to every deployment
+initContainers: []
+  # - name: wait-for-something
+  #   image: busybox:latest
+  #   command: ['sh', '-c', 'do-something-here']
+
+# -- NodeSelector for all workloads
+nodeSelector: {}
+
+# -- Tolerations for all workloads
+tolerations: []
+
+# -- Affinity for all workloads
+affinity: {}
+
+server:
+  # -- Number of Gunicorn server replicas (ignored when autoscaling is enabled)
+  replicaCount: 1
+  # -- Grace period for the server pod to finish in-flight requests on shutdown
+  terminationGracePeriodSeconds: 30
+  # -- Container args (passed to the image entrypoint). Overrides the default Gunicorn command.
+  args:
+    - gunicorn
+    - --bind=0.0.0.0:8000
+    - --workers=2
+    - --threads=4
+    - --timeout=60
+    - --graceful-timeout=30
+    - --max-requests=1000
+    - --max-requests-jitter=100
+    - core.wsgi
+  # -- Deployment update strategy for the server workload
+  strategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxSurge: 1
+    #   maxUnavailable: 0
+  service:
+    # -- Kubernetes service type for HTTP traffic
+    type: ClusterIP
+    # -- Port number for HTTP traffic (the container listens on this port too)
+    port: 8000
+  # -- Liveness probe for the server container
+  livenessProbe:
+    httpGet:
+      path: /livez
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+  # -- Readiness probe for the server container
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+  # -- Startup probe for the server container
+  startupProbe:
+    httpGet:
+      path: /livez
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 30
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 1000m
+      # -- The maximum amount of memory the container can use. Memory is incompressible, so this
+      # matches the request to keep the pod out of the early-eviction path.
+      memory: 768Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 500m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 768Mi
+  autoscaling:
+    # -- Controls whether autoscaling is enabled for the server deployment
+    enabled: false
+    # -- Minimum number of server replicas
+    minReplicas: 1
+    # -- Maximum number of server replicas
+    maxReplicas: 10
+    # -- Target CPU utilization percentage that triggers scaling
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  pdb:
+    # -- Enable a PodDisruptionBudget for the server deployment
+    enabled: false
+    # -- Minimum available server pods (used when maxUnavailable is unset; defaults to 1)
+    minAvailable: ""
+    # -- Maximum unavailable server pods (takes precedence over minAvailable when set)
+    maxUnavailable: ""
+
+worker:
+  # -- Number of Celery worker replicas (ignored when autoscaling is enabled)
+  replicaCount: 1
+  # -- Grace period for the worker to finish in-flight tasks on shutdown
+  terminationGracePeriodSeconds: 60
+  # -- Container args for the Celery worker. Keep `--concurrency` in step with the CPU limit;
+  # without it Celery forks one process per node CPU, which will not fit the memory limit.
+  args:
+    - celery
+    - -A
+    - core
+    - worker
+    - --concurrency=2
+  # -- Liveness probe for the worker container
+  livenessProbe:
+    exec:
+      command:
+        - sh
+        - -c
+        - celery -A core inspect ping -d celery@$HOSTNAME
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+  # -- Readiness probe for the worker container
+  readinessProbe:
+    exec:
+      command:
+        - sh
+        - -c
+        - celery -A core inspect ping -d celery@$HOSTNAME
+    initialDelaySeconds: 15
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+  autoscaling:
+    # -- Controls whether autoscaling is enabled for the worker deployment
+    enabled: false
+    # -- Minimum number of worker replicas
+    minReplicas: 1
+    # -- Maximum number of worker replicas
+    maxReplicas: 10
+    # -- Target CPU utilization percentage that triggers scaling
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  pdb:
+    # -- Enable a PodDisruptionBudget for the worker deployment
+    enabled: false
+    # -- Minimum available worker pods (used when maxUnavailable is unset; defaults to 1)
+    minAvailable: ""
+    # -- Maximum unavailable worker pods (takes precedence over minAvailable when set)
+    maxUnavailable: ""
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 1000m
+      # -- The maximum amount of memory the container can use
+      memory: 768Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 500m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 768Mi
+
+beat:
+  # -- Grace period for the beat scheduler to shut down
+  terminationGracePeriodSeconds: 30
+  # -- Container args for the Celery beat scheduler
+  args:
+    - celery
+    - -A
+    - core
+    - beat
+  # -- Liveness probe for the beat container (disabled by default)
+  livenessProbe: {}
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 250m
+      # -- The maximum amount of memory the container can use
+      memory: 384Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 50m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 384Mi
+
+migrations:
+  # -- Run database migrations from a dedicated Job on install and upgrade. One pod migrates, so
+  # the server can scale past a single replica. Disable to migrate out-of-band; the chart assumes
+  # it is the only migrator, `manage.py migrate` is not locked.
+  enabled: true
+  # -- Block every pod in an initContainer until migrations are applied. Deliberately not in the
+  # readiness probe: that would flip healthy running pods to NotReady whenever new migrations ship.
+  waitForMigrations: true
+  # -- Seconds the initContainer waits for migrations before failing (the pod then retries)
+  waitTimeout: 300
+  # -- Container args for the migration Job
+  args:
+    - python
+    - manage.py
+    - migrate
+  # -- Number of retries before the migration Job is marked failed
+  backoffLimit: 3
+  # -- How long a finished migration Job is retained before automatic cleanup
+  ttlSecondsAfterFinished: 600
+  # -- Hard time limit for the migration Job. Unset so a long migration is never killed midway.
+  activeDeadlineSeconds: ""
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 500m
+      # -- The maximum amount of memory the container can use
+      memory: 512Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 100m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 512Mi
+
+ingress:
+  # -- Enable an ingress resource for the server Service
+  enabled: false
+  # -- Defines which ingress controller will implement the resource
+  className: ""
+  # -- Additional ingress annotations
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  # -- List of ingress hosts
+  hosts: []
+    #  - host: request.example.com
+    #    paths:
+    #      - path: /
+    #        pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    #  - secretName: request-example-tls
+    #    hosts:
+    #      - request.example.com
+
+credentials:
+  # -- Mount a Google service account key file into the credentials directory. Required only
+  # if the Google Calendar integration is used.
+  enabled: false
+  # -- Use an existing Secret holding the key file instead of creating one from `serviceAccountKey`
+  existingSecret: ""
+  # -- File name of the key inside the credentials directory (env GOOGLE_SERVICE_ACCOUNT_KEY_FILE_NAME)
+  fileName: service-account-key-file.json
+  # -- Contents of the Google service account JSON key. Ignored when `existingSecret` is set.
+  serviceAccountKey: ""
+
+# -- Non-secret environment variables rendered into a ConfigMap, shared by all roles. Keys are the
+# literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>.
+# Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts.
+config:
+  DJANGO_SETTINGS_MODULE: core.settings.production
+  # -- Comma separated list of allowed hosts. Must include your ingress host(s).
+  ALLOWED_HOSTS: ""
+  # CORS_ALLOWED_ORIGINS: "https://request.example.com"
+  # CSRF_TRUSTED_ORIGINS: "https://request.example.com"
+  # BASE_URL_DOMAIN: request.example.com
+  # LANGUAGE_CODE: hu-hu
+  # TIME_ZONE: Europe/Budapest
+  # DJANGO_ADMIN: "True"
+  # EMAIL_HOST: smtp.example.com
+  # EMAIL_PORT: "587"
+  # EMAIL_USE_TLS: "True"
+  # DEFAULT_FROM_EMAIL: noreply@example.com
+  # DEFAULT_REPLY_EMAIL: info@example.com
+  # WEEKLY_TASK_EMAIL: list@example.com
+
+# -- Sensitive environment variables rendered into a Secret, shared by all roles. Keys are the
+# literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>.
+# With postgres.enabled, DATABASE_PASSWORD defaults to postgres.auth.password.
+secrets:
+  # -- Django secret key. Generate with `openssl rand -base64 48`.
+  APP_SECRET_KEY: ""
+  # DATABASE_PASSWORD: ""
+  # AUTH_SCH_CLIENT_ID: ""
+  # AUTH_SCH_CLIENT_SECRET: ""
+  # AUTH_BSS_CLIENT_ID: ""
+  # AUTH_BSS_CLIENT_SECRET: ""
+  # AUTH_BSS_SYNC_TOKEN: ""
+  # AUTH_GOOGLE_CLIENT_ID: ""
+  # AUTH_GOOGLE_CLIENT_SECRET: ""
+  # AUTH_MICROSOFT_CLIENT_ID: ""
+  # AUTH_MICROSOFT_CLIENT_SECRET: ""
+  # SCH_EVENTS_TOKEN: ""
+  # SENTRY_URL: ""
+  # TURNSTILE_SECRET_KEY: ""
+  # EMAIL_HOST_PASSWORD: ""
+
+# -- Supply the sensitive environment variables from an existing Secret instead of `secrets`.
+# The Secret's keys must match the expected environment variable names.
+existingSecret: ""
+
+# -- Additional envFrom sources appended to every container
+extraEnvFrom: []
+  # - secretRef:
+  #     name: extra-secret
+
+# -- Additional volumes added to every pod
+extraVolumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+
+# -- Additional volume mounts added to every container
+extraVolumeMounts: []
+  # - name: foo
+  #   mountPath: /etc/foo
+  #   readOnly: true
+
+postgres:
+  # -- Enable the CloudPirates PostgreSQL chart.
+  # Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres> for possible values.
+  enabled: true
+  auth:
+    # -- Name for a custom user to create (also used as DATABASE_USER)
+    username: request_manager
+    # -- Name for a custom database to create (also used as DATABASE_NAME)
+    database: request_manager_db
+    # -- Password for the custom user (also used as DATABASE_PASSWORD). Must be set.
+    password: ""
+  # NOTE: Compose initialises PostgreSQL with a Hungarian ICU collation
+  # (`--locale-provider=icu --icu-locale=hu-HU`). Set the equivalent here if your data needs it.
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 1000m
+      # -- The maximum amount of memory the container can use
+      memory: 1Gi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 250m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 256Mi
+  containerSecurityContext:
+    # -- Run container processes as non-root user nobody
+    runAsUser: 65534
+    # -- Run container processes with nobody group
+    runAsGroup: 65534
+    seccompProfile:
+      # -- Use the container runtime default seccomp profile
+      type: RuntimeDefault
+
+redis:
+  # -- Enable the CloudPirates Redis® chart.
+  # Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis> for possible values.
+  enabled: true
+  auth:
+    # -- Enable password authentication
+    enabled: false
+  resources:
+    limits:
+      # -- The maximum amount of CPU the container can use
+      cpu: 150m
+      # -- The maximum amount of memory the container can use
+      memory: 256Mi
+    requests:
+      # -- Specifies the minimum amount of CPU that will be allocated to the container
+      cpu: 50m
+      # -- Specifies the minimum amount of memory that will be allocated to the container
+      memory: 128Mi
+  containerSecurityContext:
+    # -- Run container processes as non-root user nobody
+    runAsUser: 65534
+    # -- Run container processes with nobody group
+    runAsGroup: 65534
+    seccompProfile:
+      # -- Use the container runtime default seccomp profile
+      type: RuntimeDefault

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -293,7 +293,8 @@ credentials:
 # Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts.
 config:
   DJANGO_SETTINGS_MODULE: core.settings.production
-  # -- Comma separated list of allowed hosts. Must include your ingress host(s).
+  # -- Comma separated list of extra allowed hosts, appended to the pod IP, localhost and the
+  # Service name that the chart always sets. Add your ingress host(s) here.
   ALLOWED_HOSTS: ""
   # CORS_ALLOWED_ORIGINS: "https://request.example.com"
   # CSRF_TRUSTED_ORIGINS: "https://request.example.com"


### PR DESCRIPTION
Packages [bss-request-manager](https://github.com/KOliver94/bss-request-manager) (appVersion 1.3.1) as a chart, with PostgreSQL and Redis bundled as optional CloudPirates sub-charts.

## Workloads

- `server` - Gunicorn, behind a Service and optional Ingress
- `worker` - Celery worker
- `beat` - Celery beat, pinned to 1 replica with `Recreate` so a rollout can't overlap two schedulers and double-fire periodic tasks
- `migrate` - Job, on install and upgrade