### PR TITLE
Harden the Outline chart and restructure its configuration values

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -19,5 +19,6 @@ misconfigurations:
     statement: Used container registries are trusted
   - id: AVD-KSV-01010
     paths:
+      - charts/outline/templates/configmap.yaml
       - charts/request-manager/templates/configmap.yaml
-    statement: Actual chart will not be deployed to default namespace
+    statement: Matches on the key name only; the ConfigMap holds no sensitive values

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -31,4 +31,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/outline
   - https://github.com/outline/outline
 type: application
-version: 1.3.2
+version: 1.4.0

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
   - outline
   - wiki
   - docs
-kubeVersion: ">=1.19.0-0"
+kubeVersion: ">=1.23.0-0"
 maintainers:
   - name: Budavári Schönherz Stúdió
     url: https://github.com/BSStudio/helm-charts

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -31,4 +31,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/outline
   - https://github.com/outline/outline
 type: application
-version: 1.4.0
+version: 2.0.0

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -53,11 +53,11 @@ Kubernetes: `>=1.23.0-0`
 | minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
 | nameOverride | string | `""` | Provide a name in place of `outline` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
-| outline.database_url | string | `"postgres://outline:secretPassword@{{ .Release.Name }}-postgres:5432/outline"` | Connection string to access the database |
+| outline.database_url | string | built from `postgres.auth` when the bundled sub-chart is enabled | Connection string to access the database. Set this to point at an external database. |
 | outline.file_storage | string | `"local"` | Specify what storage system to use. Possible value is one of "s3" or "local". |
 | outline.file_storage_upload_max_size | string | `"50000000"` | Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string. |
 | outline.pgsslmode | string | `"disable"` | Disable SSL for connecting to PostgreSQL |
-| outline.redis_url | string | `"redis://{{ .Release.Name }}-redis:6379"` | Connection string to access Redis |
+| outline.redis_url | string | built from the bundled sub-chart when it is enabled | Connection string to access Redis. Set this to point at an external cache. |
 | outline.secret_key | string | `""` | Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32` in your terminal to generate a random value. |
 | outline.url | string | `"https://outline.example.com"` | URL should point to the fully qualified, publicly accessible URL. |
 | outline.utils_secret | string | `""` | Generate a unique random key. The format is not important but you could still use `openssl rand -hex 32` in your terminal to produce this. |
@@ -72,6 +72,7 @@ Kubernetes: `>=1.23.0-0`
 | podLabels | object | `{}` | Optional additional labels to add to the pods |
 | podSecurityContext | object | `{}` | Pod-level security context, merged over chart defaults (fsGroup 65534 for volume writes) |
 | postgres.auth.database | string | `"outline"` | Name for a custom database to create |
+| postgres.auth.password | string | `""` | Password for the custom user. Required, and must be URL-safe: it is interpolated into `outline.database_url`. |
 | postgres.auth.username | string | `"outline"` | Name for a custom user to create |
 | postgres.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
 | postgres.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -53,11 +53,11 @@ Kubernetes: `>=1.19.0-0`
 | minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
 | nameOverride | string | `""` | Provide a name in place of `outline` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
-| outline.database_url | string | `"postgres://outline:secretPassword@outline-postgres:5432/outline"` | Connection string to access the database |
+| outline.database_url | string | `"postgres://outline:secretPassword@{{ .Release.Name }}-postgres:5432/outline"` | Connection string to access the database |
 | outline.file_storage | string | `"local"` | Specify what storage system to use. Possible value is one of "s3" or "local". |
 | outline.file_storage_upload_max_size | string | `"50000000"` | Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string. |
 | outline.pgsslmode | string | `"disable"` | Disable SSL for connecting to PostgreSQL |
-| outline.redis_url | string | `"redis://outline-redis:6379"` | Connection string to access Redis |
+| outline.redis_url | string | `"redis://{{ .Release.Name }}-redis:6379"` | Connection string to access Redis |
 | outline.secret_key | string | `""` | Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32` in your terminal to generate a random value. |
 | outline.url | string | `"https://outline.example.com"` | URL should point to the fully qualified, publicly accessible URL. |
 | outline.utils_secret | string | `""` | Generate a unique random key. The format is not important but you could still use `openssl rand -hex 32` in your terminal to produce this. |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -107,7 +107,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | podLabels | object | `{}` | Optional additional labels to add to the pods |
 | podSecurityContext | object | `{}` | Pod-level security context, merged over chart defaults (fsGroup 65534 for volume writes) |
 | postgres.auth.database | string | `"outline"` | Name for a custom database to create |
-| postgres.auth.password | string | `""` | Password for the custom user. Required, and must be URL-safe: it is interpolated into `outline.database_url`. |
+| postgres.auth.password | string | `""` | Password for the custom user. Required, and must be URL-safe: it is interpolated into `secrets.DATABASE_URL`. |
 | postgres.auth.username | string | `"outline"` | Name for a custom user to create |
 | postgres.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
 | postgres.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -77,7 +77,7 @@ Kubernetes: `>=1.23.0-0`
 | postgres.resources.limits.cpu | string | `"500m"` | The maximum amount of CPU the container can use |
 | postgres.resources.limits.memory | string | `"512Mi"` | The maximum amount of memory the container can use |
 | postgres.resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
-| postgres.resources.requests.memory | string | `"256Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| postgres.resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | redis.auth.enabled | bool | `false` | Enable password authentication |
 | redis.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
 | redis.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |
@@ -85,12 +85,12 @@ Kubernetes: `>=1.23.0-0`
 | redis.resources.limits.cpu | string | `"150m"` | The maximum amount of CPU the container can use |
 | redis.resources.limits.memory | string | `"256Mi"` | The maximum amount of memory the container can use |
 | redis.resources.requests.cpu | string | `"50m"` | Specifies the minimum amount of CPU that will be allocated to the container |
-| redis.resources.requests.memory | string | `"128Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| redis.resources.requests.memory | string | `"256Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | replicaCount | int | `1` | The number of replicas to deploy |
 | resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
 | resources.limits.memory | string | `"1Gi"` | The maximum amount of memory the container can use |
 | resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
-| resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| resources.requests.memory | string | `"1Gi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | scheduler.activeDeadlineSeconds | int | `300` | Hard time limit for a single run before it is killed (guards against a hung request) |
 | scheduler.annotations | object | `{}` | Optional additional annotations to add to the CronJob runner pod |
 | scheduler.backoffLimit | int | `1` | Number of retries before a run is marked failed |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -98,7 +98,9 @@ Kubernetes: `>=1.23.0-0`
 | scheduler.enabled | bool | `true` | Create a CronJob to run Outline's scheduled jobs. Refer to <https://docs.getoutline.com/s/hosting/doc/scheduled-jobs-RhZzCt770H> for more information. |
 | scheduler.failedJobsHistoryLimit | int | `3` | How many failed jobs to retain for debugging |
 | scheduler.labels | object | `{}` | Optional additional labels to add to the CronJob runner pod |
+| scheduler.podSecurityContext | object | `{}` | Pod-level security context for the runner pod, merged over the chart defaults. Separate from the top-level `podSecurityContext`, which applies to Outline itself. |
 | scheduler.schedule | string | `"30 12 * * *"` | Schedule to use for the CronJob |
+| scheduler.securityContext | object | `{}` | Container-level security context for the runner container, merged over the chart defaults. Separate from the top-level `securityContext`, which applies to Outline itself. |
 | scheduler.successfulJobsHistoryLimit | int | `3` | How many completed jobs to retain |
 | scheduler.timeZone | string | `"Europe/Budapest"` | Timezone for interpreting the cron schedule |
 | securityContext | object | `{}` | Run containers as a specific securityContext |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -66,12 +66,13 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | autoscaling.maxReplicas | int | `100` | Sets the maximum number of application instances (replicas) that can be scaled up to during high demand |
 | autoscaling.minReplicas | int | `1` | Defines the minimum number of application instances (replicas) to maintain, even during low demand |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Specifies the CPU utilization threshold at which autoscaling will be triggered to adjust the number of replicas |
-| config | object | `{"FILE_STORAGE":"local","FILE_STORAGE_UPLOAD_MAX_SIZE":"50000000","PGSSLMODE":"disable","URL":"https://outline.example.com"}` | Non-secret environment variables rendered into a ConfigMap. Keys are the literal names from <https://github.com/outline/outline/blob/main/.env.sample>. |
+| config | object | `{"FILE_STORAGE":"local","FILE_STORAGE_UPLOAD_MAX_SIZE":"50000000","FORCE_HTTPS":"false","PGSSLMODE":"disable","URL":"https://outline.example.com"}` | Non-secret environment variables rendered into a ConfigMap. Keys are the literal names from <https://github.com/outline/outline/blob/main/.env.sample>. |
 | config.FILE_STORAGE | string | `"local"` | Storage system to use, either "s3" or "local" |
 | config.FILE_STORAGE_UPLOAD_MAX_SIZE | string | `"50000000"` | Maximum allowed byte size for an uploaded attachment. Must be a string. |
+| config.FORCE_HTTPS | string | `"false"` | Redirect HTTP to HTTPS in the application. Leave false when TLS is terminated by the ingress. |
 | config.PGSSLMODE | string | `"disable"` | SSL mode for connecting to PostgreSQL |
 | config.URL | string | `"https://outline.example.com"` | Fully qualified, publicly accessible URL |
-| env | list | `[]` | Environment variables to pass to the deployment See configuration options at <https://github.com/outline/outline/blob/main/.env.sample> |
+| env | list | `[]` | Additional environment variables, appended to the container verbatim. Prefer `config` and `secrets`; entries here take precedence over both. |
 | envFrom | list | `[]` | envFrom to pass to the deployment |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for the containers |
 | extraVolumes | list | `[]` | Additional volumes to mount to the deployment |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -1,6 +1,6 @@
 # outline
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
 
 Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -74,6 +74,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | config.URL | string | `"https://outline.example.com"` | Fully qualified, publicly accessible URL |
 | env | list | `[]` | Additional environment variables, appended to the container verbatim. Prefer `config` and `secrets`; entries here take precedence over both. |
 | envFrom | list | `[]` | envFrom to pass to the deployment |
+| existingSecret | string | `""` | Read the sensitive environment variables from an existing Secret instead of `secrets`. Its keys must be the environment variable names. The connection strings below are still chart-managed. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for the containers |
 | extraVolumes | list | `[]` | Additional volumes to mount to the deployment |
 | fullnameOverride | string | `""` | String to fully override `"outline.fullname"` |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -19,7 +19,7 @@ Outline is a fast, collaborative, knowledge base for your team built using React
 
 ## Requirements
 
-Kubernetes: `>=1.19.0-0`
+Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -1,6 +1,6 @@
 # outline
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
 
 Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 
@@ -27,6 +27,36 @@ Kubernetes: `>=1.23.0-0`
 | oci://registry-1.docker.io/cloudpirates | postgres | 0.19.6 |
 | oci://registry-1.docker.io/cloudpirates | redis | 0.30.6 |
 
+## Upgrading
+
+### 1.x to 2.0
+
+The `outline` values block is replaced by `config` (rendered into a ConfigMap) and `secrets`
+(rendered into a Secret). Keys are now the literal environment variable names from Outline's
+[.env.sample](https://github.com/outline/outline/blob/main/.env.sample), so `outline.secret_key`
+becomes `secrets.SECRET_KEY`, and a nested `outline.smtp.host` becomes `config.SMTP_HOST`.
+
+```yaml
+# before
+outline:
+  secret_key: "..."
+  utils_secret: "..."
+  url: https://wiki.example.com
+  database_url: postgres://outline:hunter2@outline-postgres:5432/outline
+
+# after
+config:
+  URL: https://wiki.example.com
+secrets:
+  SECRET_KEY: "..."
+  UTILS_SECRET: "..."
+```
+
+`DATABASE_URL` and `REDIS_URL` no longer need to be set when the bundled sub-charts are used: they
+are built from `postgres.auth` and the release name. Set `postgres.auth.password` instead, which
+previously had to be kept in sync with the password embedded in `outline.database_url`. Set
+`secrets.DATABASE_URL` explicitly only to point at an external database.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -36,6 +66,11 @@ Kubernetes: `>=1.23.0-0`
 | autoscaling.maxReplicas | int | `100` | Sets the maximum number of application instances (replicas) that can be scaled up to during high demand |
 | autoscaling.minReplicas | int | `1` | Defines the minimum number of application instances (replicas) to maintain, even during low demand |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Specifies the CPU utilization threshold at which autoscaling will be triggered to adjust the number of replicas |
+| config | object | `{"FILE_STORAGE":"local","FILE_STORAGE_UPLOAD_MAX_SIZE":"50000000","PGSSLMODE":"disable","URL":"https://outline.example.com"}` | Non-secret environment variables rendered into a ConfigMap. Keys are the literal names from <https://github.com/outline/outline/blob/main/.env.sample>. |
+| config.FILE_STORAGE | string | `"local"` | Storage system to use, either "s3" or "local" |
+| config.FILE_STORAGE_UPLOAD_MAX_SIZE | string | `"50000000"` | Maximum allowed byte size for an uploaded attachment. Must be a string. |
+| config.PGSSLMODE | string | `"disable"` | SSL mode for connecting to PostgreSQL |
+| config.URL | string | `"https://outline.example.com"` | Fully qualified, publicly accessible URL |
 | env | list | `[]` | Environment variables to pass to the deployment See configuration options at <https://github.com/outline/outline/blob/main/.env.sample> |
 | envFrom | list | `[]` | envFrom to pass to the deployment |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for the containers |
@@ -53,14 +88,6 @@ Kubernetes: `>=1.23.0-0`
 | minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
 | nameOverride | string | `""` | Provide a name in place of `outline` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
-| outline.database_url | string | built from `postgres.auth` when the bundled sub-chart is enabled | Connection string to access the database. Set this to point at an external database. |
-| outline.file_storage | string | `"local"` | Specify what storage system to use. Possible value is one of "s3" or "local". |
-| outline.file_storage_upload_max_size | string | `"50000000"` | Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string. |
-| outline.pgsslmode | string | `"disable"` | Disable SSL for connecting to PostgreSQL |
-| outline.redis_url | string | built from the bundled sub-chart when it is enabled | Connection string to access Redis. Set this to point at an external cache. |
-| outline.secret_key | string | `""` | Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32` in your terminal to generate a random value. |
-| outline.url | string | `"https://outline.example.com"` | URL should point to the fully qualified, publicly accessible URL. |
-| outline.utils_secret | string | `""` | Generate a unique random key. The format is not important but you could still use `openssl rand -hex 32` in your terminal to produce this. |
 | pdb.enabled | bool | `false` | Enable a PodDisruptionBudget. With a single replica `minAvailable: 1` blocks node drains. |
 | pdb.maxUnavailable | string | `""` | Maximum unavailable pods (takes precedence over minAvailable when set) |
 | pdb.minAvailable | string | `""` | Minimum available pods (used when maxUnavailable is unset; defaults to 1) |
@@ -107,6 +134,9 @@ Kubernetes: `>=1.23.0-0`
 | scheduler.securityContext | object | `{}` | Container-level security context for the runner container, merged over the chart defaults |
 | scheduler.successfulJobsHistoryLimit | int | `3` | How many completed jobs to retain |
 | scheduler.timeZone | string | `"Europe/Budapest"` | Timezone for interpreting the cron schedule |
+| secrets | object | `{"SECRET_KEY":"","UTILS_SECRET":""}` | Sensitive environment variables rendered into a Secret. Keys are the literal names from <https://github.com/outline/outline/blob/main/.env.sample>. DATABASE_URL and REDIS_URL default to the bundled sub-charts; set them to point at an external database or cache. |
+| secrets.SECRET_KEY | string | `""` | Hex-encoded 32-byte random key. Generate with `openssl rand -hex 32`. |
+| secrets.UTILS_SECRET | string | `""` | Unique random key. Generate with `openssl rand -hex 32`. |
 | securityContext | object | `{}` | Run containers as a specific securityContext |
 | service.port | int | `3000` | Port number for web traffic |
 | service.type | string | `"ClusterIP"` | Kubernetes service type for web traffic |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -114,4 +114,5 @@ Kubernetes: `>=1.23.0-0`
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | strategy | object | `{}` | Deployment update strategy. When empty, defaults to `Recreate` if persistence is enabled with a non-`ReadWriteMany` access mode (avoids a RWO volume deadlock on upgrade), otherwise Kubernetes' default RollingUpdate is used. |
+| terminationGracePeriodSeconds | int | `75` | Grace period for shutdown. Above Outline's own 60s force-quit timeout, so it is not killed mid-drain. |
 | tolerations | list | `[]` | Tolerations for the deployment |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -81,6 +81,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | image.imagePullPolicy | string | `"IfNotPresent"` | The logic of image pulling |
 | image.repository | string | `"outlinewiki/outline"` | The Docker repository to pull the image from |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| imagePullSecrets | list | `[]` | Secrets for pulling the image from a private registry |
 | ingress.annotations | object | `{}` | Additional ingress annotations |
 | ingress.className | string | `""` | Defines which ingress controller will implement the resource |
 | ingress.enabled | bool | `false` | Enable an ingress resource |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -61,6 +61,9 @@ Kubernetes: `>=1.23.0-0`
 | outline.secret_key | string | `""` | Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32` in your terminal to generate a random value. |
 | outline.url | string | `"https://outline.example.com"` | URL should point to the fully qualified, publicly accessible URL. |
 | outline.utils_secret | string | `""` | Generate a unique random key. The format is not important but you could still use `openssl rand -hex 32` in your terminal to produce this. |
+| pdb.enabled | bool | `false` | Enable a PodDisruptionBudget. With a single replica `minAvailable: 1` blocks node drains. |
+| pdb.maxUnavailable | string | `""` | Maximum unavailable pods (takes precedence over minAvailable when set) |
+| pdb.minAvailable | string | `""` | Minimum available pods (used when maxUnavailable is unset; defaults to 1) |
 | persistence.accessMode | string | `"ReadWriteOnce"` | Specifies the level of access to the persistent storage (e.g., read-write, read-only) |
 | persistence.annotations | object | `{}` | Annotations to add to the PVC, e.g. `helm.sh/resource-policy: keep` to retain data on uninstall |
 | persistence.enabled | bool | `true` | Determines whether persistent storage is enabled or not |
@@ -98,9 +101,9 @@ Kubernetes: `>=1.23.0-0`
 | scheduler.enabled | bool | `true` | Create a CronJob to run Outline's scheduled jobs. Refer to <https://docs.getoutline.com/s/hosting/doc/scheduled-jobs-RhZzCt770H> for more information. |
 | scheduler.failedJobsHistoryLimit | int | `3` | How many failed jobs to retain for debugging |
 | scheduler.labels | object | `{}` | Optional additional labels to add to the CronJob runner pod |
-| scheduler.podSecurityContext | object | `{}` | Pod-level security context for the runner pod, merged over the chart defaults. Separate from the top-level `podSecurityContext`, which applies to Outline itself. |
+| scheduler.podSecurityContext | object | `{}` | Pod-level security context for the runner pod, merged over the chart defaults |
 | scheduler.schedule | string | `"30 12 * * *"` | Schedule to use for the CronJob |
-| scheduler.securityContext | object | `{}` | Container-level security context for the runner container, merged over the chart defaults. Separate from the top-level `securityContext`, which applies to Outline itself. |
+| scheduler.securityContext | object | `{}` | Container-level security context for the runner container, merged over the chart defaults |
 | scheduler.successfulJobsHistoryLimit | int | `3` | How many completed jobs to retain |
 | scheduler.timeZone | string | `"Europe/Budapest"` | Timezone for interpreting the cron schedule |
 | securityContext | object | `{}` | Run containers as a specific securityContext |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -66,12 +66,12 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the deployment |
-| autoscaling.enabled | bool | `false` | Controls whether autoscaling is enabled or disabled for the application |
+| autoscaling.enabled | bool | `false` | Controls whether autoscaling is enabled or disabled for the application. Scaling past one replica needs `config.FILE_STORAGE` set to "s3", or a ReadWriteMany volume. |
 | autoscaling.maxReplicas | int | `100` | Sets the maximum number of application instances (replicas) that can be scaled up to during high demand |
 | autoscaling.minReplicas | int | `1` | Defines the minimum number of application instances (replicas) to maintain, even during low demand |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Specifies the CPU utilization threshold at which autoscaling will be triggered to adjust the number of replicas |
 | config | object | `{"FILE_STORAGE":"local","FILE_STORAGE_UPLOAD_MAX_SIZE":"50000000","FORCE_HTTPS":"false","PGSSLMODE":"disable","URL":"https://outline.example.com"}` | Non-secret environment variables rendered into a ConfigMap. Keys are the literal names from <https://github.com/outline/outline/blob/main/.env.sample>. |
-| config.FILE_STORAGE | string | `"local"` | Storage system to use, either "s3" or "local" |
+| config.FILE_STORAGE | string | `"local"` | Storage system to use, either "s3" or "local". "local" needs `persistence` enabled, and pins the deployment to one node unless the volume is ReadWriteMany. |
 | config.FILE_STORAGE_UPLOAD_MAX_SIZE | string | `"50000000"` | Maximum allowed byte size for an uploaded attachment. Must be a string. |
 | config.FORCE_HTTPS | string | `"false"` | Redirect HTTP to HTTPS in the application. Leave false when TLS is terminated by the ingress. |
 | config.PGSSLMODE | string | `"disable"` | SSL mode for connecting to PostgreSQL |
@@ -99,7 +99,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | pdb.enabled | bool | `false` | Enable a PodDisruptionBudget. With a single replica `minAvailable: 1` blocks node drains. |
 | pdb.maxUnavailable | string | `""` | Maximum unavailable pods (takes precedence over minAvailable when set) |
 | pdb.minAvailable | string | `""` | Minimum available pods (used when maxUnavailable is unset; defaults to 1) |
-| persistence.accessMode | string | `"ReadWriteOnce"` | Specifies the level of access to the persistent storage (e.g., read-write, read-only) |
+| persistence.accessMode | string | `"ReadWriteOnce"` | Access mode for the volume. ReadWriteMany is required to run more than one replica while `config.FILE_STORAGE` is "local". |
 | persistence.annotations | object | `{}` | Annotations to add to the PVC, e.g. `helm.sh/resource-policy: keep` to retain data on uninstall |
 | persistence.enabled | bool | `true` | Determines whether persistent storage is enabled or not |
 | persistence.size | string | `"2Gi"` | Defines the amount of storage allocated for persistence |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -52,6 +52,10 @@ secrets:
   UTILS_SECRET: "..."
 ```
 
+`envFrom` is renamed to `extraEnvFrom`, matching the other charts in this repository. Entries under
+`env` are now passed to the container verbatim instead of being folded into the Secret, so a plain
+`value` is visible in the pod spec; move anything sensitive to `secrets`.
+
 `DATABASE_URL` and `REDIS_URL` no longer need to be set when the bundled sub-charts are used: they
 are built from `postgres.auth` and the release name. Set `postgres.auth.password` instead, which
 previously had to be kept in sync with the password embedded in `outline.database_url`. Set
@@ -73,8 +77,8 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | config.PGSSLMODE | string | `"disable"` | SSL mode for connecting to PostgreSQL |
 | config.URL | string | `"https://outline.example.com"` | Fully qualified, publicly accessible URL |
 | env | list | `[]` | Additional environment variables, appended to the container verbatim. Prefer `config` and `secrets`; entries here take precedence over both. |
-| envFrom | list | `[]` | envFrom to pass to the deployment |
 | existingSecret | string | `""` | Read the sensitive environment variables from an existing Secret instead of `secrets`. Its keys must be the environment variable names. The connection strings below are still chart-managed. |
+| extraEnvFrom | list | `[]` | Additional envFrom sources appended to the container |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for the containers |
 | extraVolumes | list | `[]` | Additional volumes to mount to the deployment |
 | fullnameOverride | string | `""` | String to fully override `"outline.fullname"` |
@@ -88,6 +92,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | ingress.hosts | list | `[]` | List of ingress hosts |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | Init containers to add to the deployment |
+| livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"tcpSocket":{"port":"http"}}` | Liveness probe for the container. Not /_health: it queries Postgres and Redis, so an outage would restart every replica. |
 | minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
 | nameOverride | string | `""` | Provide a name in place of `outline` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |
@@ -112,6 +117,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | postgres.resources.limits.memory | string | `"512Mi"` | The maximum amount of memory the container can use |
 | postgres.resources.requests.cpu | string | `"250m"` | Specifies the minimum amount of CPU that will be allocated to the container |
 | postgres.resources.requests.memory | string | `"512Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/_health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe for the container |
 | redis.auth.enabled | bool | `false` | Enable password authentication |
 | redis.containerSecurityContext.runAsGroup | int | `65534` | Run container processes with nobody group |
 | redis.containerSecurityContext.runAsUser | int | `65534` | Run container processes as non-root user nobody |
@@ -147,6 +153,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
+| startupProbe | object | `{"failureThreshold":30,"httpGet":{"path":"/_health","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Startup probe for the container |
 | strategy | object | `{}` | Deployment update strategy. When empty, defaults to `Recreate` if persistence is enabled with a non-`ReadWriteMany` access mode (avoids a RWO volume deadlock on upgrade), otherwise Kubernetes' default RollingUpdate is used. |
 | terminationGracePeriodSeconds | int | `75` | Grace period for shutdown. Above Outline's own 60s force-quit timeout, so it is not killed mid-drain. |
 | tolerations | list | `[]` | Tolerations for the deployment |

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -52,9 +52,9 @@ secrets:
   UTILS_SECRET: "..."
 ```
 
-`envFrom` is renamed to `extraEnvFrom`, matching the other charts in this repository. Entries under
-`env` are now passed to the container verbatim instead of being folded into the Secret, so a plain
-`value` is visible in the pod spec; move anything sensitive to `secrets`.
+`env` and `envFrom` are renamed to `extraEnv` and `extraEnvFrom`, matching the other charts in this
+repository. Entries under `extraEnv` are now passed to the container verbatim instead of being folded
+into the Secret, so a plain `value` is visible in the pod spec; move anything sensitive to `secrets`.
 
 `DATABASE_URL` and `REDIS_URL` no longer need to be set when the bundled sub-charts are used: they
 are built from `postgres.auth` and the release name. Set `postgres.auth.password` instead, which
@@ -76,8 +76,8 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | config.FORCE_HTTPS | string | `"false"` | Redirect HTTP to HTTPS in the application. Leave false when TLS is terminated by the ingress. |
 | config.PGSSLMODE | string | `"disable"` | SSL mode for connecting to PostgreSQL |
 | config.URL | string | `"https://outline.example.com"` | Fully qualified, publicly accessible URL |
-| env | list | `[]` | Additional environment variables, appended to the container verbatim. Prefer `config` and `secrets`; entries here take precedence over both. |
 | existingSecret | string | `""` | Read the sensitive environment variables from an existing Secret instead of `secrets`. Its keys must be the environment variable names. The connection strings below are still chart-managed. |
+| extraEnv | list | `[]` | Additional environment variables, appended to the container verbatim. Prefer `config` and `secrets`; entries here take precedence over both. |
 | extraEnvFrom | list | `[]` | Additional envFrom sources appended to the container |
 | extraVolumeMounts | list | `[]` | Additional volume mounts for the containers |
 | extraVolumes | list | `[]` | Additional volumes to mount to the deployment |

--- a/charts/outline/README.md.gotmpl
+++ b/charts/outline/README.md.gotmpl
@@ -37,6 +37,10 @@ secrets:
   UTILS_SECRET: "..."
 ```
 
+`envFrom` is renamed to `extraEnvFrom`, matching the other charts in this repository. Entries under
+`env` are now passed to the container verbatim instead of being folded into the Secret, so a plain
+`value` is visible in the pod spec; move anything sensitive to `secrets`.
+
 `DATABASE_URL` and `REDIS_URL` no longer need to be set when the bundled sub-charts are used: they
 are built from `postgres.auth` and the release name. Set `postgres.auth.password` instead, which
 previously had to be kept in sync with the password embedded in `outline.database_url`. Set

--- a/charts/outline/README.md.gotmpl
+++ b/charts/outline/README.md.gotmpl
@@ -37,9 +37,9 @@ secrets:
   UTILS_SECRET: "..."
 ```
 
-`envFrom` is renamed to `extraEnvFrom`, matching the other charts in this repository. Entries under
-`env` are now passed to the container verbatim instead of being folded into the Secret, so a plain
-`value` is visible in the pod spec; move anything sensitive to `secrets`.
+`env` and `envFrom` are renamed to `extraEnv` and `extraEnvFrom`, matching the other charts in this
+repository. Entries under `extraEnv` are now passed to the container verbatim instead of being folded
+into the Secret, so a plain `value` is visible in the pod spec; move anything sensitive to `secrets`.
 
 `DATABASE_URL` and `REDIS_URL` no longer need to be set when the bundled sub-charts are used: they
 are built from `postgres.auth` and the release name. Set `postgres.auth.password` instead, which

--- a/charts/outline/README.md.gotmpl
+++ b/charts/outline/README.md.gotmpl
@@ -1,0 +1,45 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Upgrading
+
+### 1.x to 2.0
+
+The `outline` values block is replaced by `config` (rendered into a ConfigMap) and `secrets`
+(rendered into a Secret). Keys are now the literal environment variable names from Outline's
+[.env.sample](https://github.com/outline/outline/blob/main/.env.sample), so `outline.secret_key`
+becomes `secrets.SECRET_KEY`, and a nested `outline.smtp.host` becomes `config.SMTP_HOST`.
+
+```yaml
+# before
+outline:
+  secret_key: "..."
+  utils_secret: "..."
+  url: https://wiki.example.com
+  database_url: postgres://outline:hunter2@outline-postgres:5432/outline
+
+# after
+config:
+  URL: https://wiki.example.com
+secrets:
+  SECRET_KEY: "..."
+  UTILS_SECRET: "..."
+```
+
+`DATABASE_URL` and `REDIS_URL` no longer need to be set when the bundled sub-charts are used: they
+are built from `postgres.auth` and the release name. Set `postgres.auth.password` instead, which
+previously had to be kept in sync with the password embedded in `outline.database_url`. Set
+`secrets.DATABASE_URL` explicitly only to point at an external database.
+
+{{ template "chart.valuesSection" . }}

--- a/charts/outline/ci/default-values.yaml
+++ b/charts/outline/ci/default-values.yaml
@@ -2,8 +2,6 @@
 outline:
   secret_key: 96250aac910f511334f52e9b609713305abb5bf8329188879fcc1c5b3e983aa4
   utils_secret: 69e576155ecfbc380ccb5d7a7293a6e97aca9039e22f5ecadf8f0d49c266879e
-  database_url: postgres://outline:secretPassword@{{ .Release.Name }}-postgres:5432/outline
-  redis_url: redis://{{ .Release.Name }}-redis:6379
 
 postgres:
   auth:

--- a/charts/outline/ci/default-values.yaml
+++ b/charts/outline/ci/default-values.yaml
@@ -2,8 +2,8 @@
 outline:
   secret_key: 96250aac910f511334f52e9b609713305abb5bf8329188879fcc1c5b3e983aa4
   utils_secret: 69e576155ecfbc380ccb5d7a7293a6e97aca9039e22f5ecadf8f0d49c266879e
-  database_url: postgres://outline:secretPassword@{{ include "outline.fullname" . }}-postgres:5432/outline
-  redis_url: redis://{{ include "outline.fullname" . }}-redis:6379
+  database_url: postgres://outline:secretPassword@{{ .Release.Name }}-postgres:5432/outline
+  redis_url: redis://{{ .Release.Name }}-redis:6379
 
 postgres:
   auth:

--- a/charts/outline/ci/default-values.yaml
+++ b/charts/outline/ci/default-values.yaml
@@ -1,7 +1,7 @@
 ---
-outline:
-  secret_key: 96250aac910f511334f52e9b609713305abb5bf8329188879fcc1c5b3e983aa4
-  utils_secret: 69e576155ecfbc380ccb5d7a7293a6e97aca9039e22f5ecadf8f0d49c266879e
+secrets:
+  SECRET_KEY: 96250aac910f511334f52e9b609713305abb5bf8329188879fcc1c5b3e983aa4
+  UTILS_SECRET: 69e576155ecfbc380ccb5d7a7293a6e97aca9039e22f5ecadf8f0d49c266879e
 
 postgres:
   auth:

--- a/charts/outline/ci/fullname-override-values.yaml
+++ b/charts/outline/ci/fullname-override-values.yaml
@@ -4,9 +4,9 @@
 
 fullnameOverride: mywiki
 
-outline:
-  secret_key: 9c04e7b1a35d826f0b4c8e1d7a35906c2fb8e04d19a7c3b5e02f6d8a4b1c937e
-  utils_secret: 3e91d7c05a2bf846d0c937e1a58b4f26097cd3ba51e8f704b6a29d3c85e0f172
+secrets:
+  SECRET_KEY: 9c04e7b1a35d826f0b4c8e1d7a35906c2fb8e04d19a7c3b5e02f6d8a4b1c937e
+  UTILS_SECRET: 3e91d7c05a2bf846d0c937e1a58b4f26097cd3ba51e8f704b6a29d3c85e0f172
 
 postgres:
   auth:

--- a/charts/outline/ci/fullname-override-values.yaml
+++ b/charts/outline/ci/fullname-override-values.yaml
@@ -1,0 +1,15 @@
+---
+# Drives `outline.fullname` away from the release name. The bundled sub-charts stay named after the
+# release, so a connection string built from the fullname points at a Service that does not exist.
+# `ct` always generates a release name containing the chart name, which is why this needs an
+# explicit override to surface.
+
+fullnameOverride: mywiki
+
+outline:
+  secret_key: 9c04e7b1a35d826f0b4c8e1d7a35906c2fb8e04d19a7c3b5e02f6d8a4b1c937e
+  utils_secret: 3e91d7c05a2bf846d0c937e1a58b4f26097cd3ba51e8f704b6a29d3c85e0f172
+
+postgres:
+  auth:
+    password: secretPassword

--- a/charts/outline/ci/fullname-override-values.yaml
+++ b/charts/outline/ci/fullname-override-values.yaml
@@ -1,8 +1,6 @@
 ---
-# Drives `outline.fullname` away from the release name. The bundled sub-charts stay named after the
-# release, so a connection string built from the fullname points at a Service that does not exist.
-# `ct` always generates a release name containing the chart name, which is why this needs an
-# explicit override to surface.
+# Drives `outline.fullname` away from the release name, which the bundled sub-charts are named after.
+# `ct` always generates a release name containing the chart name, so this needs an explicit override.
 
 fullnameOverride: mywiki
 

--- a/charts/outline/ci/ingress-values.yaml
+++ b/charts/outline/ci/ingress-values.yaml
@@ -1,0 +1,17 @@
+---
+# Ingress enabled with pathType omitted, so the chart default is what the API server validates.
+
+outline:
+  secret_key: 4f8c1d2ba9e6374c05fbd8a71e93c62d40b7fa5981ce3d0672b4a8e5f1c9037d
+  utils_secret: 8d3b7f0a1c9e52d6438fb0c7a25e91d3670c4fb28a5d19e36f0b74c8d2a5e913
+
+postgres:
+  auth:
+    password: secretPassword
+
+ingress:
+  enabled: true
+  hosts:
+    - host: outline.example.com
+      paths:
+        - path: /

--- a/charts/outline/ci/ingress-values.yaml
+++ b/charts/outline/ci/ingress-values.yaml
@@ -1,9 +1,9 @@
 ---
 # Ingress enabled with pathType omitted, so the chart default is what the API server validates.
 
-outline:
-  secret_key: 4f8c1d2ba9e6374c05fbd8a71e93c62d40b7fa5981ce3d0672b4a8e5f1c9037d
-  utils_secret: 8d3b7f0a1c9e52d6438fb0c7a25e91d3670c4fb28a5d19e36f0b74c8d2a5e913
+secrets:
+  SECRET_KEY: 4f8c1d2ba9e6374c05fbd8a71e93c62d40b7fa5981ce3d0672b4a8e5f1c9037d
+  UTILS_SECRET: 8d3b7f0a1c9e52d6438fb0c7a25e91d3670c4fb28a5d19e36f0b74c8d2a5e913
 
 postgres:
   auth:

--- a/charts/outline/ci/security-overrides-values.yaml
+++ b/charts/outline/ci/security-overrides-values.yaml
@@ -1,9 +1,9 @@
 ---
 # Exercises the security context merge helpers. Every key below differs from the chart defaults.
 
-outline:
-  secret_key: 1a7e93c05fb8d2647c0e3f9a15bd6820c47fe9a3b0d58126fc94e07a3b5d81f6
-  utils_secret: 26fbc0a94d7e13580b6ca2f84e09d735182bf6ca0e94d7538201bfc6a4e9d370
+secrets:
+  SECRET_KEY: 1a7e93c05fb8d2647c0e3f9a15bd6820c47fe9a3b0d58126fc94e07a3b5d81f6
+  UTILS_SECRET: 26fbc0a94d7e13580b6ca2f84e09d735182bf6ca0e94d7538201bfc6a4e9d370
 
 postgres:
   auth:

--- a/charts/outline/ci/security-overrides-values.yaml
+++ b/charts/outline/ci/security-overrides-values.yaml
@@ -1,6 +1,5 @@
 ---
-# Exercises the security context merge helpers. Every key below differs from the chart defaults, so
-# a merge that silently drops user input fails here rather than rendering something plausible.
+# Exercises the security context merge helpers. Every key below differs from the chart defaults.
 
 outline:
   secret_key: 1a7e93c05fb8d2647c0e3f9a15bd6820c47fe9a3b0d58126fc94e07a3b5d81f6

--- a/charts/outline/ci/security-overrides-values.yaml
+++ b/charts/outline/ci/security-overrides-values.yaml
@@ -1,0 +1,28 @@
+---
+# Exercises the security context merge helpers. Every key below differs from the chart defaults, so
+# a merge that silently drops user input fails here rather than rendering something plausible.
+
+outline:
+  secret_key: 1a7e93c05fb8d2647c0e3f9a15bd6820c47fe9a3b0d58126fc94e07a3b5d81f6
+  utils_secret: 26fbc0a94d7e13580b6ca2f84e09d735182bf6ca0e94d7538201bfc6a4e9d370
+
+postgres:
+  auth:
+    password: secretPassword
+
+# Nested merge: `add` must apply without losing the default `drop: [ALL]`.
+securityContext:
+  capabilities:
+    add:
+      - NET_BIND_SERVICE
+
+podSecurityContext:
+  fsGroupChangePolicy: Always
+
+scheduler:
+  securityContext:
+    capabilities:
+      add:
+        - NET_BIND_SERVICE
+  podSecurityContext:
+    runAsNonRoot: true

--- a/charts/outline/templates/NOTES.txt
+++ b/charts/outline/templates/NOTES.txt
@@ -19,12 +19,14 @@ then open http://127.0.0.1:{{ .Values.service.port }}
 {{- end }}
 
 Configured public URL: {{ .Values.config.URL }}
+{{- if not .Values.existingSecret }}
 {{- if not .Values.secrets.SECRET_KEY }}
 
 WARNING: secrets.SECRET_KEY is empty — set it (openssl rand -hex 32) or Outline will not start.
 {{- end }}
 {{- if not .Values.secrets.UTILS_SECRET }}
 WARNING: secrets.UTILS_SECRET is empty — set it (openssl rand -hex 32) or Outline will not start.
+{{- end }}
 {{- end }}
 {{- if and .Values.postgres.enabled (not .Values.postgres.auth.password) }}
 WARNING: postgres.auth.password is empty — set it or Outline cannot reach the bundled database.

--- a/charts/outline/templates/NOTES.txt
+++ b/charts/outline/templates/NOTES.txt
@@ -31,3 +31,13 @@ WARNING: secrets.UTILS_SECRET is empty — set it (openssl rand -hex 32) or Outl
 {{- if and .Values.postgres.enabled (not .Values.postgres.auth.password) }}
 WARNING: postgres.auth.password is empty — set it or Outline cannot reach the bundled database.
 {{- end }}
+{{- if eq "local" (.Values.config.FILE_STORAGE | toString) }}
+{{- if not .Values.persistence.enabled }}
+WARNING: FILE_STORAGE is "local" but persistence is disabled. The root filesystem is read-only, so
+uploads will fail. Enable persistence, or set config.FILE_STORAGE to "s3".
+{{- else if and (or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1)) (ne .Values.persistence.accessMode "ReadWriteMany") }}
+WARNING: FILE_STORAGE is "local" on a {{ .Values.persistence.accessMode }} volume, which only one
+node can mount. Replicas beyond the first will fail to schedule. Use ReadWriteMany, or set
+config.FILE_STORAGE to "s3".
+{{- end }}
+{{- end }}

--- a/charts/outline/templates/NOTES.txt
+++ b/charts/outline/templates/NOTES.txt
@@ -18,11 +18,14 @@ Outline is exposed on a {{ .Values.service.type }} Service. To reach it from you
 then open http://127.0.0.1:{{ .Values.service.port }}
 {{- end }}
 
-Configured public URL: {{ .Values.outline.url }}
-{{- if not .Values.outline.secret_key }}
+Configured public URL: {{ .Values.config.URL }}
+{{- if not .Values.secrets.SECRET_KEY }}
 
-WARNING: outline.secret_key is empty — set it (openssl rand -hex 32) or Outline will not start.
+WARNING: secrets.SECRET_KEY is empty — set it (openssl rand -hex 32) or Outline will not start.
 {{- end }}
-{{- if not .Values.outline.utils_secret }}
-WARNING: outline.utils_secret is empty — set it (openssl rand -hex 32) or Outline will not start.
+{{- if not .Values.secrets.UTILS_SECRET }}
+WARNING: secrets.UTILS_SECRET is empty — set it (openssl rand -hex 32) or Outline will not start.
+{{- end }}
+{{- if and .Values.postgres.enabled (not .Values.postgres.auth.password) }}
+WARNING: postgres.auth.password is empty — set it or Outline cannot reach the bundled database.
 {{- end }}

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -113,44 +113,43 @@ mounts no volumes.
 {{- end }}
 
 {{/*
-Outline settings, with the connection strings defaulted from the bundled sub-charts so that
-`postgres.auth` stays the single source of truth for the credentials. Either URL can still be set
-explicitly, which is what pointing at an external database or cache looks like.
+Non-secret environment variables. Empty values are dropped so that blanking a default in a values
+file removes the variable rather than setting it to "".
 */}}
-{{- define "outline.settings" -}}
-{{- $settings := deepCopy .Values.outline -}}
-{{- if and .Values.postgres.enabled (not .Values.outline.database_url) .Values.postgres.auth.password -}}
-{{- $auth := .Values.postgres.auth -}}
-{{- $_ := set $settings "database_url" (printf "postgres://%s:%s@%s-postgres:5432/%s" $auth.username $auth.password .Release.Name $auth.database) -}}
-{{- end -}}
-{{- if and .Values.redis.enabled (not .Values.outline.redis_url) -}}
-{{- $_ := set $settings "redis_url" (printf "redis://%s-redis:6379" .Release.Name) -}}
-{{- end -}}
-{{- toYaml $settings -}}
+{{- define "outline.config" -}}
+{{- range $k, $v := .Values.config }}
+{{- $rendered := tpl ($v | toString) $ }}
+{{- if $rendered }}
+{{ $k }}: {{ $rendered | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
-Create outline configuration environment variables.
+Sensitive environment variables. The connection strings default to the bundled sub-charts, keeping
+`postgres.auth` the single source of truth for the credentials; setting either explicitly is what
+pointing at an external database or cache looks like.
 */}}
-{{- define "outline.env" -}}
-{{- range $k, $v := .values }}
-  {{- if kindIs "map" $v }}
-    {{- range $sk, $sv := $v }}
-      {{- include "outline.env" (dict "root" $.root "values" (dict (printf "%s_%s" (upper $k) (upper $sk)) $sv)) }}
-    {{- end }}
-  {{- else }}
-    {{- $value := $v }}
-    {{- if or (kindIs "bool" $v) (kindIs "float64" $v) (kindIs "int" $v) (kindIs "int64" $v) }}
-      {{- $v = $v | toString | b64enc | quote -}}
-    {{- else }}
-      {{- $v = tpl $v $.root | toString | b64enc | quote }}
-    {{- end }}
-    {{- if and ($v) (ne $v "\"\"") }}
-{{ upper $k }}: {{ $v }}
-    {{- end }}
-  {{- end }}
-{{- end }}
+{{- define "outline.secrets" -}}
+{{- $computed := dict -}}
+{{- if and .Values.postgres.enabled .Values.postgres.auth.password -}}
+{{- $auth := .Values.postgres.auth -}}
+{{- $_ := set $computed "DATABASE_URL" (printf "postgres://%s:%s@%s-postgres:5432/%s" $auth.username $auth.password .Release.Name $auth.database) -}}
 {{- end -}}
+{{- if .Values.redis.enabled -}}
+{{- $_ := set $computed "REDIS_URL" (printf "redis://%s-redis:6379" .Release.Name) -}}
+{{- end -}}
+{{- $user := dict -}}
+{{- range $k, $v := .Values.secrets -}}
+{{- $rendered := tpl ($v | toString) $ -}}
+{{- if $rendered -}}
+{{- $_ := set $user $k $rendered -}}
+{{- end -}}
+{{- end -}}
+{{- range $k, $v := merge $user $computed }}
+{{ $k }}: {{ $v | b64enc | quote }}
+{{- end }}
+{{- end }}
 
 {{/*
 Transform environment variables to be added to secret.
@@ -182,7 +181,7 @@ Generate environment variables.
     value: "false"
   - name: PORT
     value: {{ .Values.service.port | quote }}
-  {{- if eq "local" $.Values.outline.file_storage }}
+  {{- if eq "local" (.Values.config.FILE_STORAGE | toString) }}
   - name: FILE_STORAGE_LOCAL_ROOT_DIR
     value: "/var/lib/outline/data"
   {{- end }}

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -140,15 +140,24 @@ pointing at an external database or cache looks like.
 {{- $_ := set $computed "REDIS_URL" (printf "redis://%s-redis:6379" .Release.Name) -}}
 {{- end -}}
 {{- $user := dict -}}
+{{- if not .Values.existingSecret -}}
 {{- range $k, $v := .Values.secrets -}}
 {{- $rendered := tpl ($v | toString) $ -}}
 {{- if $rendered -}}
 {{- $_ := set $user $k $rendered -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
 {{- range $k, $v := merge $user $computed }}
 {{ $k }}: {{ $v | b64enc | quote }}
 {{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the user-supplied secrets, for consumers that read a single key.
+*/}}
+{{- define "outline.secretName" -}}
+{{- default (include "outline.fullname" .) .Values.existingSecret }}
 {{- end }}
 
 {{/*

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -113,6 +113,23 @@ mounts no volumes.
 {{- end }}
 
 {{/*
+Outline settings, with the connection strings defaulted from the bundled sub-charts so that
+`postgres.auth` stays the single source of truth for the credentials. Either URL can still be set
+explicitly, which is what pointing at an external database or cache looks like.
+*/}}
+{{- define "outline.settings" -}}
+{{- $settings := deepCopy .Values.outline -}}
+{{- if and .Values.postgres.enabled (not .Values.outline.database_url) .Values.postgres.auth.password -}}
+{{- $auth := .Values.postgres.auth -}}
+{{- $_ := set $settings "database_url" (printf "postgres://%s:%s@%s-postgres:5432/%s" $auth.username $auth.password .Release.Name $auth.database) -}}
+{{- end -}}
+{{- if and .Values.redis.enabled (not .Values.outline.redis_url) -}}
+{{- $_ := set $settings "redis_url" (printf "redis://%s-redis:6379" .Release.Name) -}}
+{{- end -}}
+{{- toYaml $settings -}}
+{{- end }}
+
+{{/*
 Create outline configuration environment variables.
 */}}
 {{- define "outline.env" -}}

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -176,7 +176,7 @@ the ConfigMap and Secret, so entries here silently override them.
 - name: FILE_STORAGE_LOCAL_ROOT_DIR
   value: /var/lib/outline/data
 {{- end }}
-{{- with .Values.env }}
+{{- with .Values.extraEnv }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -90,6 +90,29 @@ Pod-level security context shared by every pod.
 {{- end }}
 
 {{/*
+Security contexts for the scheduler CronJob. Deliberately separate from the application ones: the
+runner is busybox rather than Outline, and it mounts no volumes, so the app's fsGroup does not apply.
+*/}}
+{{- define "outline.schedulerPodSecurityContext" -}}
+{{- $defaults := dict
+  "seccompProfile" (dict "type" "RuntimeDefault")
+-}}
+{{- toYaml (mustMergeOverwrite $defaults (deepCopy (default dict .Values.scheduler.podSecurityContext))) }}
+{{- end }}
+
+{{- define "outline.schedulerSecurityContext" -}}
+{{- $defaults := dict
+  "runAsUser" 65534
+  "runAsGroup" 65534
+  "allowPrivilegeEscalation" false
+  "runAsNonRoot" true
+  "readOnlyRootFilesystem" true
+  "capabilities" (dict "drop" (list "ALL"))
+-}}
+{{- toYaml (mustMergeOverwrite $defaults (deepCopy (default dict .Values.scheduler.securityContext))) }}
+{{- end }}
+
+{{/*
 Create outline configuration environment variables.
 */}}
 {{- define "outline.env" -}}

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Create the name of the service account to use
 
 {{/*
 Container-level security context for the application container.
-Merged as a dict so user keys override the defaults instead of being appended as duplicates.
+Merged as a dict so user keys override the defaults rather than being appended as duplicates.
 */}}
 {{- define "outline.containerSecurityContext" -}}
 {{- $defaults := dict
@@ -90,8 +90,8 @@ Pod-level security context shared by every pod.
 {{- end }}
 
 {{/*
-Security contexts for the scheduler CronJob. Deliberately separate from the application ones: the
-runner is busybox rather than Outline, and it mounts no volumes, so the app's fsGroup does not apply.
+Security contexts for the scheduler CronJob. Separate from the application ones: it runs busybox and
+mounts no volumes.
 */}}
 {{- define "outline.schedulerPodSecurityContext" -}}
 {{- $defaults := dict

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -62,6 +62,34 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Container-level security context for the application container.
+Merged as a dict so user keys override the defaults instead of being appended as duplicates.
+*/}}
+{{- define "outline.containerSecurityContext" -}}
+{{- $defaults := dict
+  "runAsUser" 65534
+  "runAsGroup" 65534
+  "allowPrivilegeEscalation" false
+  "runAsNonRoot" true
+  "readOnlyRootFilesystem" true
+  "capabilities" (dict "drop" (list "ALL"))
+-}}
+{{- toYaml (mustMergeOverwrite $defaults (deepCopy (default dict .Values.securityContext))) }}
+{{- end }}
+
+{{/*
+Pod-level security context shared by every pod.
+*/}}
+{{- define "outline.podSecurityContext" -}}
+{{- $defaults := dict
+  "seccompProfile" (dict "type" "RuntimeDefault")
+  "fsGroup" 65534
+  "fsGroupChangePolicy" "OnRootMismatch"
+-}}
+{{- toYaml (mustMergeOverwrite $defaults (deepCopy (default dict .Values.podSecurityContext))) }}
+{{- end }}
+
+{{/*
 Create outline configuration environment variables.
 */}}
 {{- define "outline.env" -}}

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -152,44 +152,22 @@ pointing at an external database or cache looks like.
 {{- end }}
 
 {{/*
-Transform environment variables to be added to secret.
+Environment variables the chart derives from other values, followed by the user's `env` entries.
+Anything a user should be able to change belongs in `config` or `secrets` instead: `env` wins over
+the ConfigMap and Secret, so entries here silently override them.
 */}}
-{{- define "outline.envVars" -}}
-{{- range $env := .Values.env }}
-  {{- if and (hasKey $env "name") (hasKey $env "value") }}
-{{ $env.name }}: {{ $env.value | toString | b64enc | quote }}
-  {{- end }}
+{{- define "outline.env" -}}
+- name: NODE_ENV
+  value: production
+- name: HOME
+  value: /tmp
+- name: PORT
+  value: {{ .Values.service.port | quote }}
+{{- if eq "local" (.Values.config.FILE_STORAGE | toString) }}
+- name: FILE_STORAGE_LOCAL_ROOT_DIR
+  value: /var/lib/outline/data
+{{- end }}
+{{- with .Values.env }}
+{{ toYaml . }}
 {{- end }}
 {{- end }}
-
-{{/*
-Generate environment variables.
-*/}}
-{{- define "outline.generateEnvVars" -}}
-  {{- $envVarsWithValueFrom := list -}}
-  {{- range $env := .Values.env -}}
-    {{- if and (hasKey $env "name") (hasKey $env "valueFrom") -}}
-      {{- $envVarsWithValueFrom = append $envVarsWithValueFrom (dict "name" $env.name "valueFrom" $env.valueFrom) }}
-    {{- end -}}
-  {{- end -}}
-  env:
-  - name: NODE_ENV
-    value: "production"
-  - name: HOME
-    value: "/tmp"
-  - name: FORCE_HTTPS
-    value: "false"
-  - name: PORT
-    value: {{ .Values.service.port | quote }}
-  {{- if eq "local" (.Values.config.FILE_STORAGE | toString) }}
-  - name: FILE_STORAGE_LOCAL_ROOT_DIR
-    value: "/var/lib/outline/data"
-  {{- end }}
-  {{- if not (empty $envVarsWithValueFrom) }}
-  {{- range $env := $envVarsWithValueFrom }}
-  - name: {{ $env.name }}
-    valueFrom:
-{{ toYaml $env.valueFrom | indent 6 }}
-  {{- end }}
-  {{- end }}
-{{- end -}}

--- a/charts/outline/templates/configmap.yaml
+++ b/charts/outline/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "outline.fullname" . }}
+  labels:
+    {{- include "outline.labels" . | nindent 4 }}
+data:
+  {{- include "outline.config" . | trim | nindent 2 }}

--- a/charts/outline/templates/configmap.yaml
+++ b/charts/outline/templates/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     {{- include "outline.labels" . | nindent 4 }}
 data:
-  {{- include "outline.config" . | trim | nindent 2 }}
+  {{- include "outline.config" . | trim | default "{}" | nindent 2 }}

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -58,7 +58,7 @@ spec:
                 - name: UTILS_SECRET
                   valueFrom:
                     secretKeyRef:
-                      name: {{ include "outline.fullname" . }}
+                      name: {{ include "outline.secretName" . }}
                       key: UTILS_SECRET
               resources:
                 requests:

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -29,21 +29,13 @@ spec:
         spec:
           automountServiceAccountToken: false
           securityContext:
-            seccompProfile:
-              type: RuntimeDefault
+            {{- include "outline.schedulerPodSecurityContext" . | nindent 12 }}
           containers:
             - name: invoke-scheduler
               image: busybox:stable-uclibc
               imagePullPolicy: Always
               securityContext:
-                runAsUser: 65534
-                runAsGroup: 65534
-                allowPrivilegeEscalation: false
-                runAsNonRoot: true
-                readOnlyRootFilesystem: true
-                capabilities:
-                  drop:
-                    - ALL
+                {{- include "outline.schedulerSecurityContext" . | nindent 16 }}
               command: [/bin/sh]
               args:
                 - -c

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -23,6 +23,7 @@ spec:
           {{- end }}
           labels:
             {{- include "outline.labels" . | nindent 12 }}
+            app.kubernetes.io/component: scheduler
             {{- with .Values.scheduler.labels }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/outline/templates/cronjob.yaml
+++ b/charts/outline/templates/cronjob.yaml
@@ -62,7 +62,7 @@ spec:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 128Mi
+                  memory: 192Mi
                 limits:
                   cpu: 150m
                   memory: 192Mi

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
@@ -75,6 +76,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
+            - configMapRef:
+                name: {{ include "outline.fullname" . }}
             - secretRef:
                 name: {{ include "outline.fullname" . }}
             {{- with .Values.envFrom }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "outline.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
                 name: {{ include "outline.fullname" . }}
             - secretRef:
                 name: {{ include "outline.fullname" . }}
+            {{- with .Values.existingSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
             {{- with .Values.envFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       serviceAccountName: {{ include "outline.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- include "outline.podSecurityContext" . | nindent 8 }}
       {{- with .Values.initContainers }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -56,27 +56,18 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          # Not /_health: it queries Postgres and Redis, so an outage would restart every replica.
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            tcpSocket:
-              port: http
-            initialDelaySeconds: 5
-            failureThreshold: 3
-            periodSeconds: 10
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /_health
-              port: http
-            initialDelaySeconds: 5
-            failureThreshold: 3
-            periodSeconds: 10
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
           startupProbe:
-            httpGet:
-              path: /_health
-              port: http
-            initialDelaySeconds: 5
-            failureThreshold: 30
-            periodSeconds: 10
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
@@ -88,7 +79,7 @@ spec:
             - secretRef:
                 name: {{ . }}
             {{- end }}
-            {{- with .Values.envFrom }}
+            {{- with .Values.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           env:

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
       labels:
         {{- include "outline.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -49,9 +49,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          # Not /_health: it queries Postgres and Redis, so an outage would restart every replica.
           livenessProbe:
-            httpGet:
-              path: /_health
+            tcpSocket:
               port: http
             initialDelaySeconds: 5
             failureThreshold: 3

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -83,7 +83,8 @@ spec:
             {{- with .Values.envFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- include "outline.generateEnvVars" . | nindent 10 }}
+          env:
+            {{- include "outline.env" . | trim | nindent 12 }}
           {{- if or .Values.persistence.enabled .Values.extraVolumes }}
           volumeMounts:
             - name: {{ include "outline.fullname" . }}-tmp

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -34,13 +34,7 @@ spec:
       serviceAccountName: {{ include "outline.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        fsGroup: 65534
-        fsGroupChangePolicy: OnRootMismatch
-        {{- with .Values.podSecurityContext }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "outline.podSecurityContext" . | nindent 8 }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -48,17 +42,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            runAsUser: 65534
-            runAsGroup: 65534
-            allowPrivilegeEscalation: false
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
-            {{- with .Values.securityContext }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "outline.containerSecurityContext" . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           ports:

--- a/charts/outline/templates/ingress.yaml
+++ b/charts/outline/templates/ingress.yaml
@@ -32,9 +32,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/charts/outline/templates/pdb.yaml
+++ b/charts/outline/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "outline.fullname" . }}
+  labels:
+    {{- include "outline.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  {{- end }}
+  # Scoped by component: the scheduler and test pods share the selector labels.
+  selector:
+    matchLabels:
+      {{- include "outline.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+{{- end }}

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -7,6 +7,3 @@ metadata:
 type: Opaque
 data:
   {{- include "outline.secrets" . | trim | nindent 2 }}
-  {{- with (include "outline.envVars" . | trim) }}
-  {{- . | nindent 2 }}
-  {{- end }}

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -6,5 +6,7 @@ metadata:
     {{- include "outline.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- include "outline.env" (dict "root" . "values" (fromYaml (include "outline.settings" .))) | indent 2 }}
-  {{- include "outline.envVars" . | indent 2 }}
+  {{- include "outline.secrets" . | trim | nindent 2 }}
+  {{- with (include "outline.envVars" . | trim) }}
+  {{- . | nindent 2 }}
+  {{- end }}

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
     {{- include "outline.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- include "outline.env" (dict "root" . "values" .Values.outline) | indent 2 }}
+  {{- include "outline.env" (dict "root" . "values" (fromYaml (include "outline.settings" .))) | indent 2 }}
   {{- include "outline.envVars" . | indent 2 }}

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "outline.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- include "outline.secrets" . | trim | nindent 2 }}
+  {{- include "outline.secrets" . | trim | default "{}" | nindent 2 }}

--- a/charts/outline/templates/service.yaml
+++ b/charts/outline/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "outline.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/charts/outline/templates/tests/test-connection.yaml
+++ b/charts/outline/templates/tests/test-connection.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ printf "%s-test-connection" (include "outline.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
     {{- include "outline.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
   annotations:
     helm.sh/hook: test
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -126,6 +126,14 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+pdb:
+  # -- Enable a PodDisruptionBudget. With a single replica `minAvailable: 1` blocks node drains.
+  enabled: false
+  # -- Maximum unavailable pods (takes precedence over minAvailable when set)
+  maxUnavailable: ""
+  # -- Minimum available pods (used when maxUnavailable is unset; defaults to 1)
+  minAvailable: ""
+
 # -- Environment variables to pass to the deployment
 # See configuration options at <https://github.com/outline/outline/blob/main/.env.sample>
 env: []
@@ -220,11 +228,9 @@ scheduler:
   annotations: {}
   # -- Optional additional labels to add to the CronJob runner pod
   labels: {}
-  # -- Pod-level security context for the runner pod, merged over the chart defaults. Separate from
-  # the top-level `podSecurityContext`, which applies to Outline itself.
+  # -- Pod-level security context for the runner pod, merged over the chart defaults
   podSecurityContext: {}
-  # -- Container-level security context for the runner container, merged over the chart defaults.
-  # Separate from the top-level `securityContext`, which applies to Outline itself.
+  # -- Container-level security context for the runner container, merged over the chart defaults
   securityContext: {}
 
 minio:

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -80,7 +80,7 @@ ingress:
     #  - host: chart-example.local
     #    paths:
     #      - path: /
-    #        pathType: ImplementationSpecific
+    #        pathType: Prefix
     # -- Ingress TLS configuration
   tls: []
     #  - secretName: chart-example-tls

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -136,7 +136,8 @@ resources:
 persistence:
   # -- Determines whether persistent storage is enabled or not
   enabled: true
-  # -- Specifies the level of access to the persistent storage (e.g., read-write, read-only)
+  # -- Access mode for the volume. ReadWriteMany is required to run more than one replica while
+  # `config.FILE_STORAGE` is "local".
   accessMode: ReadWriteOnce
   # -- Defines the amount of storage allocated for persistence
   size: 2Gi
@@ -149,7 +150,8 @@ persistence:
   # storageClass:
 
 autoscaling:
-  # -- Controls whether autoscaling is enabled or disabled for the application
+  # -- Controls whether autoscaling is enabled or disabled for the application. Scaling past one
+  # replica needs `config.FILE_STORAGE` set to "s3", or a ReadWriteMany volume.
   enabled: false
   # -- Defines the minimum number of application instances (replicas) to maintain, even during low demand
   minReplicas: 1
@@ -222,7 +224,8 @@ config:
   FORCE_HTTPS: "false"
   # -- SSL mode for connecting to PostgreSQL
   PGSSLMODE: disable
-  # -- Storage system to use, either "s3" or "local"
+  # -- Storage system to use, either "s3" or "local". "local" needs `persistence` enabled, and pins
+  # the deployment to one node unless the volume is ReadWriteMany.
   FILE_STORAGE: local
   # -- Maximum allowed byte size for an uploaded attachment. Must be a string.
   FILE_STORAGE_UPLOAD_MAX_SIZE: "50000000"

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -172,7 +172,7 @@ pdb:
 
 # -- Additional environment variables, appended to the container verbatim. Prefer `config` and
 # `secrets`; entries here take precedence over both.
-env: []
+extraEnv: []
   # - name: ENV_VAR_NAME
   #   value: VALUE
   # - name: ENV_VAR_OTHER

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -94,6 +94,33 @@ ingress:
     #    hosts:
     #      - chart-example.local
 
+# -- Liveness probe for the container. Not /_health: it queries Postgres and Redis, so an outage
+# would restart every replica.
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+# -- Readiness probe for the container
+readinessProbe:
+  httpGet:
+    path: /_health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+# -- Startup probe for the container
+startupProbe:
+  httpGet:
+    path: /_health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 30
+
 resources:
   limits:
     # -- The maximum amount of CPU the container can use
@@ -157,8 +184,8 @@ env: []
   #       name: config-map-name
   #       key: config-map-key
 
-# -- envFrom to pass to the deployment
-envFrom: []
+# -- Additional envFrom sources appended to the container
+extraEnvFrom: []
   # - configMapRef:
   #     name: config-map-name
   # - secretRef:

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -287,7 +287,7 @@ postgres:
     # -- Name for a custom database to create
     database: outline
     # -- Password for the custom user. Required, and must be URL-safe: it is interpolated into
-    # `outline.database_url`.
+    # `secrets.DATABASE_URL`.
     password: ""
   resources:
     limits:

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -12,6 +12,9 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
 
+# -- Secrets for pulling the image from a private registry
+imagePullSecrets: []
+
 # -- The number of replicas to deploy
 replicaCount: 1
 

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -181,13 +181,13 @@ outline:
   utils_secret: ""
 
   # -- Connection string to access the database
-  database_url: postgres://outline:secretPassword@outline-postgres:5432/outline
+  database_url: postgres://outline:secretPassword@{{ .Release.Name }}-postgres:5432/outline
 
   # -- Disable SSL for connecting to PostgreSQL
   pgsslmode: disable
 
   # -- Connection string to access Redis
-  redis_url: redis://outline-redis:6379
+  redis_url: redis://{{ .Release.Name }}-redis:6379
 
   # -- URL should point to the fully qualified, publicly accessible URL.
   url: https://outline.example.com

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -183,34 +183,28 @@ tolerations: []
 # -- Affinity for the deployment
 affinity: {}
 
-outline:
-  # -- Generate a hex-encoded 32-byte random key. You should use `openssl rand -hex 32`
-  # in your terminal to generate a random value.
-  secret_key: ""
+# -- Non-secret environment variables rendered into a ConfigMap. Keys are the literal names from
+# <https://github.com/outline/outline/blob/main/.env.sample>.
+config:
+  # -- Fully qualified, publicly accessible URL
+  URL: https://outline.example.com
+  # -- SSL mode for connecting to PostgreSQL
+  PGSSLMODE: disable
+  # -- Storage system to use, either "s3" or "local"
+  FILE_STORAGE: local
+  # -- Maximum allowed byte size for an uploaded attachment. Must be a string.
+  FILE_STORAGE_UPLOAD_MAX_SIZE: "50000000"
 
-  # -- Generate a unique random key. The format is not important but you could still use
-  # `openssl rand -hex 32` in your terminal to produce this.
-  utils_secret: ""
-
-  # -- Connection string to access the database. Set this to point at an external database.
-  # @default -- built from `postgres.auth` when the bundled sub-chart is enabled
-  database_url: ""
-
-  # -- Disable SSL for connecting to PostgreSQL
-  pgsslmode: disable
-
-  # -- Connection string to access Redis. Set this to point at an external cache.
-  # @default -- built from the bundled sub-chart when it is enabled
-  redis_url: ""
-
-  # -- URL should point to the fully qualified, publicly accessible URL.
-  url: https://outline.example.com
-
-  # -- Specify what storage system to use. Possible value is one of "s3" or "local".
-  file_storage: local
-
-  # -- Maximum allowed byte size for the uploaded attachment. Make sure to define it as a string.
-  file_storage_upload_max_size: "50000000"
+# -- Sensitive environment variables rendered into a Secret. Keys are the literal names from
+# <https://github.com/outline/outline/blob/main/.env.sample>. DATABASE_URL and REDIS_URL default to
+# the bundled sub-charts; set them to point at an external database or cache.
+secrets:
+  # -- Hex-encoded 32-byte random key. Generate with `openssl rand -hex 32`.
+  SECRET_KEY: ""
+  # -- Unique random key. Generate with `openssl rand -hex 32`.
+  UTILS_SECRET: ""
+  # DATABASE_URL: ""
+  # REDIS_URL: ""
 
 scheduler:
   # -- Create a CronJob to run Outline's scheduled jobs.

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -15,6 +15,10 @@ image:
 # -- The number of replicas to deploy
 replicaCount: 1
 
+# -- Grace period for shutdown. Above Outline's own 60s force-quit timeout, so it is not killed
+# mid-drain.
+terminationGracePeriodSeconds: 75
+
 # -- Deployment update strategy. When empty, defaults to `Recreate` if persistence
 # is enabled with a non-`ReadWriteMany` access mode (avoids a RWO volume deadlock
 # on upgrade), otherwise Kubernetes' default RollingUpdate is used.

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -192,14 +192,16 @@ outline:
   # `openssl rand -hex 32` in your terminal to produce this.
   utils_secret: ""
 
-  # -- Connection string to access the database
-  database_url: postgres://outline:secretPassword@{{ .Release.Name }}-postgres:5432/outline
+  # -- Connection string to access the database. Set this to point at an external database.
+  # @default -- built from `postgres.auth` when the bundled sub-chart is enabled
+  database_url: ""
 
   # -- Disable SSL for connecting to PostgreSQL
   pgsslmode: disable
 
-  # -- Connection string to access Redis
-  redis_url: redis://{{ .Release.Name }}-redis:6379
+  # -- Connection string to access Redis. Set this to point at an external cache.
+  # @default -- built from the bundled sub-chart when it is enabled
+  redis_url: ""
 
   # -- URL should point to the fully qualified, publicly accessible URL.
   url: https://outline.example.com
@@ -251,7 +253,9 @@ postgres:
     username: outline
     # -- Name for a custom database to create
     database: outline
-    # password: "secretPassword"
+    # -- Password for the custom user. Required, and must be URL-safe: it is interpolated into
+    # `outline.database_url`.
+    password: ""
   resources:
     limits:
       # -- The maximum amount of CPU the container can use

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -97,7 +97,7 @@ resources:
     # -- Specifies the minimum amount of CPU that will be allocated to the container
     cpu: 250m
     # -- Specifies the minimum amount of memory that will be allocated to the container
-    memory: 512Mi
+    memory: 1Gi
 
 persistence:
   # -- Determines whether persistent storage is enabled or not
@@ -252,7 +252,7 @@ postgres:
       # -- Specifies the minimum amount of CPU that will be allocated to the container
       cpu: 250m
       # -- Specifies the minimum amount of memory that will be allocated to the container
-      memory: 256Mi
+      memory: 512Mi
   containerSecurityContext:
     # -- Run container processes as non-root user nobody
     runAsUser: 65534
@@ -279,7 +279,7 @@ redis:
       # -- Specifies the minimum amount of CPU that will be allocated to the container
       cpu: 50m
       # -- Specifies the minimum amount of memory that will be allocated to the container
-      memory: 128Mi
+      memory: 256Mi
   containerSecurityContext:
     # -- Run container processes as non-root user nobody
     runAsUser: 65534

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -197,6 +197,10 @@ config:
   # -- Maximum allowed byte size for an uploaded attachment. Must be a string.
   FILE_STORAGE_UPLOAD_MAX_SIZE: "50000000"
 
+# -- Read the sensitive environment variables from an existing Secret instead of `secrets`. Its keys
+# must be the environment variable names. The connection strings below are still chart-managed.
+existingSecret: ""
+
 # -- Sensitive environment variables rendered into a Secret. Keys are the literal names from
 # <https://github.com/outline/outline/blob/main/.env.sample>. DATABASE_URL and REDIS_URL default to
 # the bundled sub-charts; set them to point at an external database or cache.

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -220,6 +220,12 @@ scheduler:
   annotations: {}
   # -- Optional additional labels to add to the CronJob runner pod
   labels: {}
+  # -- Pod-level security context for the runner pod, merged over the chart defaults. Separate from
+  # the top-level `podSecurityContext`, which applies to Outline itself.
+  podSecurityContext: {}
+  # -- Container-level security context for the runner container, merged over the chart defaults.
+  # Separate from the top-level `securityContext`, which applies to Outline itself.
+  securityContext: {}
 
 minio:
   # -- Enable the CloudPirates MinIO® chart.

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -138,8 +138,8 @@ pdb:
   # -- Minimum available pods (used when maxUnavailable is unset; defaults to 1)
   minAvailable: ""
 
-# -- Environment variables to pass to the deployment
-# See configuration options at <https://github.com/outline/outline/blob/main/.env.sample>
+# -- Additional environment variables, appended to the container verbatim. Prefer `config` and
+# `secrets`; entries here take precedence over both.
 env: []
   # - name: ENV_VAR_NAME
   #   value: VALUE
@@ -188,6 +188,8 @@ affinity: {}
 config:
   # -- Fully qualified, publicly accessible URL
   URL: https://outline.example.com
+  # -- Redirect HTTP to HTTPS in the application. Leave false when TLS is terminated by the ingress.
+  FORCE_HTTPS: "false"
   # -- SSL mode for connecting to PostgreSQL
   PGSSLMODE: disable
   # -- Storage system to use, either "s3" or "local"

--- a/scripts/helm-docs.sh
+++ b/scripts/helm-docs.sh
@@ -4,10 +4,15 @@ set -eux
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Git Bash rewrites the container-side "/helm-docs" into a Windows path, which silently mounts the
+# volume somewhere else. No effect on Linux or macOS.
+export MSYS_NO_PATHCONV=1
+
 echo -e "\n-- Running helm-docs --\n"
 docker run \
     --rm \
     --volume "$REPO_ROOT:/helm-docs" \
     --user "$(id --user)" \
     jnorwood/helm-docs:v1.14.2 \
+    --chart-search-root=charts \
     --skip-version-footer


### PR DESCRIPTION
## Bugs fixed

- **Connection hosts were wrong unless the release was named `outline`.** `helm install mywiki bsstudio/outline` told the app to reach `mywiki-outline-postgres` while the Service was `mywiki-postgres`. Broken install, no error. CI never caught it because `ct` generates release names containing the chart name, so the two coincided.
- **Default install could not reach its own database.** With `postgres.auth.password` unset the sub-chart generated a random password while the app was told `secretPassword`. Masked in CI by `ci/default-values.yaml` pinning it.
- **Ingress rendered without `pathType`,** which is required on `networking.k8s.io/v1` — following the commented example in `values.yaml` produced a manifest the API server rejects.
- **Security context overrides were appended, not merged,** producing duplicate YAML keys. A nested `capabilities.add` replaced the default `drop: [ALL]`, silently unhardening the container.
- **The Service selector matched the scheduler and test pods.** Masked only because `targetPort` is a named port busybox does not declare.
- **`kubeVersion` claimed `>=1.19`** while the chart renders `autoscaling/v2` (1.23).

## Behaviour changes

- Liveness moved to `tcpSocket`. `/_health` queries Postgres and Redis ([source](https://github.com/outline/outline/blob/main/server/index.ts)), so a dependency blip restarted every replica. Readiness and startup still use it — that is what they are for.
- `terminationGracePeriodSeconds: 75`, above Outline's own 60s `forceQuitTimeout`. The inherited 30s default was killing it mid-drain.
- Memory requests now equal their limits; memory is incompressible, so the gap only understated the pods to the scheduler.

## Values restructure (breaking)

`outline:` is replaced by `config:` (ConfigMap) and `secrets:` (Secret), keyed by the literal env var names from Outline's `.env.sample`. `DATABASE_URL` and `REDIS_URL` are derived from
`postgres.auth` and the release name, so the password lives in exactly one place. `env:` entries now go to the container verbatim instead of being folded into the Secret. `envFrom` is renamed
`extraEnvFrom` to match request-manager.

Migration notes are in the chart README, which now has a `README.md.gotmpl` so they survive helm-docs regeneration.

## Added

`existingSecret`, `imagePullSecrets`, an opt-in PodDisruptionBudget, component labels, overridable scheduler security contexts, and NOTES warnings for missing secrets and for `FILE_STORAGE: local` configurations that cannot support the requested replica count.