### PR TITLE
Move request-manager image to BSStudio org

### DIFF
--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 1.3.2
+appVersion: 1.4.0
 dependencies:
   - condition: postgres.enabled
     name: postgres
@@ -11,8 +11,8 @@ dependencies:
     repository: oci://registry-1.docker.io/cloudpirates
     version: 0.30.6
 description: Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
-home: https://github.com/KOliver94/bss-request-manager
-# image: ghcr.io/koliver94/bss-request-manager
+home: https://github.com/BSStudio/request-manager
+# image: ghcr.io/bsstudio/request-manager
 keywords:
   - request-manager
   - video-requests
@@ -26,6 +26,6 @@ maintainers:
 name: request-manager
 sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/request-manager
-  - https://github.com/KOliver94/bss-request-manager
+  - https://github.com/BSStudio/request-manager
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -38,7 +38,7 @@ Kubernetes: `>=1.23.0-0`
 | beat.resources.requests.cpu | string | `"50m"` | Specifies the minimum amount of CPU that will be allocated to the container |
 | beat.resources.requests.memory | string | `"384Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
 | beat.terminationGracePeriodSeconds | int | `30` | Grace period for the beat scheduler to shut down |
-| config | object | `{"ALLOWED_HOSTS":"","DJANGO_SETTINGS_MODULE":"core.settings.production"}` | Non-secret environment variables rendered into a ConfigMap, shared by all roles. Keys are the literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>. Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts. |
+| config | object | `{"ALLOWED_HOSTS":"","DJANGO_SETTINGS_MODULE":"core.settings.production"}` | Non-secret environment variables rendered into a ConfigMap, shared by all roles. Keys are the literal names from <https://github.com/BSStudio/request-manager/blob/main/backend/.env.sample>. Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts. |
 | config.ALLOWED_HOSTS | string | `""` | Comma separated list of extra allowed hosts, appended to the pod IP, localhost and the Service name that the chart always sets. Add your ingress host(s) here. |
 | credentials.enabled | bool | `false` | Mount a Google service account key file into the credentials directory. Required only if the Google Calendar integration is used. |
 | credentials.existingSecret | string | `""` | Use an existing Secret holding the key file instead of creating one from `serviceAccountKey` |
@@ -96,7 +96,7 @@ Kubernetes: `>=1.23.0-0`
 | redis.resources.limits.memory | string | `"256Mi"` | The maximum amount of memory the container can use |
 | redis.resources.requests.cpu | string | `"50m"` | Specifies the minimum amount of CPU that will be allocated to the container |
 | redis.resources.requests.memory | string | `"128Mi"` | Specifies the minimum amount of memory that will be allocated to the container |
-| secrets | object | `{"APP_SECRET_KEY":""}` | Sensitive environment variables rendered into a Secret, shared by all roles. Keys are the literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>. With postgres.enabled, DATABASE_PASSWORD defaults to postgres.auth.password. |
+| secrets | object | `{"APP_SECRET_KEY":""}` | Sensitive environment variables rendered into a Secret, shared by all roles. Keys are the literal names from <https://github.com/BSStudio/request-manager/blob/main/backend/.env.sample>. With postgres.enabled, DATABASE_PASSWORD defaults to postgres.auth.password. |
 | secrets.APP_SECRET_KEY | string | `""` | Django secret key. Generate with `openssl rand -base64 48`. |
 | securityContext | object | `{}` | Container-level security context, merged over the hardened chart defaults |
 | server.args | list | `["gunicorn","--bind=0.0.0.0:8000","--workers=2","--threads=4","--timeout=60","--graceful-timeout=30","--max-requests=1000","--max-requests-jitter=100","core.wsgi"]` | Container args (passed to the image entrypoint). Overrides the default Gunicorn command. |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -1,10 +1,10 @@
 # request-manager
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.2](https://img.shields.io/badge/AppVersion-1.3.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
 
-**Homepage:** <https://github.com/KOliver94/bss-request-manager>
+**Homepage:** <https://github.com/BSStudio/request-manager>
 
 ## Maintainers
 
@@ -15,7 +15,7 @@ Manage video shooting and live streaming requests at Budavári Schönherz Stúdi
 ## Source Code
 
 * <https://github.com/BSStudio/helm-charts/tree/main/charts/request-manager>
-* <https://github.com/KOliver94/bss-request-manager>
+* <https://github.com/BSStudio/request-manager>
 
 ## Requirements
 
@@ -51,7 +51,7 @@ Kubernetes: `>=1.23.0-0`
 | extraVolumes | list | `[]` | Additional volumes added to every pod |
 | fullnameOverride | string | `""` | String to fully override `"request-manager.fullname"` |
 | image.imagePullPolicy | string | `"IfNotPresent"` | The logic of image pulling |
-| image.repository | string | `"ghcr.io/koliver94/bss-request-manager"` | The Docker repository to pull the image from |
+| image.repository | string | `"ghcr.io/bsstudio/request-manager"` | The Docker repository to pull the image from |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for the (private) container registry |
 | ingress.annotations | object | `{}` | Additional ingress annotations |

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -291,7 +291,7 @@ credentials:
   serviceAccountKey: ""
 
 # -- Non-secret environment variables rendered into a ConfigMap, shared by all roles. Keys are the
-# literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>.
+# literal names from <https://github.com/BSStudio/request-manager/blob/main/backend/.env.sample>.
 # Connection settings (DATABASE_*, CACHE_REDIS, CELERY_BROKER) default to the bundled sub-charts.
 config:
   DJANGO_SETTINGS_MODULE: core.settings.production
@@ -312,7 +312,7 @@ config:
   # WEEKLY_TASK_EMAIL: list@example.com
 
 # -- Sensitive environment variables rendered into a Secret, shared by all roles. Keys are the
-# literal names from <https://github.com/KOliver94/bss-request-manager/blob/main/backend/.env.sample>.
+# literal names from <https://github.com/BSStudio/request-manager/blob/main/backend/.env.sample>.
 # With postgres.enabled, DATABASE_PASSWORD defaults to postgres.auth.password.
 secrets:
   # -- Django secret key. Generate with `openssl rand -base64 48`.

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -6,7 +6,7 @@ fullnameOverride: ""
 
 image:
   # -- The Docker repository to pull the image from
-  repository: ghcr.io/koliver94/bss-request-manager
+  repository: ghcr.io/bsstudio/request-manager
   # -- The logic of image pulling
   imagePullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
The request-manager image moved from `KOliver94/bss-request-manager` to `BSStudio/request-manager` (dropped the `bss` prefix), published as 1.4.0 upwards.

- `image.repository` → `ghcr.io/bsstudio/request-manager`
- `appVersion` 1.3.2 → 1.4.0
- Chart `version` 0.1.0 → 0.2.0
- `home` + sources → `BSStudio/request-manager`
- README regenerated via helm-docs
