### PR TITLE
Fix Celery worker probes restarting healthy workers

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -91,7 +91,12 @@ belongs in `config`/`secrets` instead — Kubernetes gives `env` precedence over
 in `extraEnv` silently override both the ConfigMap and the Secret.
 
 Probes live in `values.yaml` (`livenessProbe`, `readinessProbe`, `startupProbe`) and are rendered
-under `{{- with }}`, so setting one to `null` disables it.
+under `{{- with }}`, so setting one to `null` disables it. `{}` does not — Helm coalesces the chart's
+default back into a user's empty map, so say `null` in the chart README.
+
+**An `exec` probe that starts an interpreter competes with the workload**, inside the same CPU limit.
+Give it a long `periodSeconds`, and check the command's own timeout: `celery inspect ping` waits 1s
+for a reply regardless of `timeoutSeconds`.
 
 ## Rules that are easy to get wrong
 

--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-appVersion: 1.4.0
+appVersion: 1.4.1
 dependencies:
   - condition: postgres.enabled
     name: postgres

--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/request-manager
   - https://github.com/BSStudio/request-manager
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -129,11 +129,11 @@ Kubernetes: `>=1.23.0-0`
 | worker.autoscaling.maxReplicas | int | `10` | Maximum number of worker replicas |
 | worker.autoscaling.minReplicas | int | `1` | Minimum number of worker replicas |
 | worker.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage that triggers scaling |
-| worker.livenessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$(hostname)"]},"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":30,"timeoutSeconds":10}` | Liveness probe for the worker container |
+| worker.livenessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$(hostname) -t 15"]},"failureThreshold":3,"initialDelaySeconds":60,"periodSeconds":60,"timeoutSeconds":30}` | Liveness probe for the worker container. Keep `-t`: celery's reply timeout defaults to 1s. |
 | worker.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the worker deployment |
 | worker.pdb.maxUnavailable | string | `""` | Maximum unavailable worker pods (takes precedence over minAvailable when set) |
 | worker.pdb.minAvailable | string | `""` | Minimum available worker pods (used when maxUnavailable is unset; defaults to 1) |
-| worker.readinessProbe | object | `{"exec":{"command":["sh","-c","celery -A core inspect ping -d celery@$(hostname)"]},"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":30,"timeoutSeconds":10}` | Readiness probe for the worker container |
+| worker.readinessProbe | object | `{}` | Readiness probe for the worker container. Disabled: the worker fronts no Service. |
 | worker.replicaCount | int | `1` | Number of Celery worker replicas (ignored when autoscaling is enabled) |
 | worker.resources.limits.cpu | string | `"1000m"` | The maximum amount of CPU the container can use |
 | worker.resources.limits.memory | string | `"768Mi"` | The maximum amount of memory the container can use |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -1,6 +1,6 @@
 # request-manager
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
 
 Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
 

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -1,6 +1,6 @@
 # request-manager
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.0](https://img.shields.io/badge/AppVersion-1.4.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
 

--- a/charts/request-manager/templates/worker/deployment.yaml
+++ b/charts/request-manager/templates/worker/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "request-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: worker
+  annotations:
+    checkov.io/skip1: CKV_K8S_9=No Service selects the worker, so readiness has no consumer
 spec:
   {{- if not .Values.worker.autoscaling.enabled }}
   replicas: {{ .Values.worker.replicaCount }}

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -150,28 +150,19 @@ worker:
     - core
     - worker
     - --concurrency=2
-  # -- Liveness probe for the worker container
+  # -- Liveness probe for the worker container. Keep `-t`: celery's reply timeout defaults to 1s.
   livenessProbe:
     exec:
       command:
         - sh
         - -c
-        - celery -A core inspect ping -d celery@$(hostname)
-    initialDelaySeconds: 30
-    periodSeconds: 30
-    timeoutSeconds: 10
+        - celery -A core inspect ping -d celery@$(hostname) -t 15
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    timeoutSeconds: 30
     failureThreshold: 3
-  # -- Readiness probe for the worker container
-  readinessProbe:
-    exec:
-      command:
-        - sh
-        - -c
-        - celery -A core inspect ping -d celery@$(hostname)
-    initialDelaySeconds: 15
-    periodSeconds: 30
-    timeoutSeconds: 10
-    failureThreshold: 3
+  # -- Readiness probe for the worker container. Disabled: the worker fronts no Service.
+  readinessProbe: {}
   autoscaling:
     # -- Controls whether autoscaling is enabled for the worker deployment
     enabled: false


### PR DESCRIPTION
`celery inspect ping` waits 1s for a reply regardless of `timeoutSeconds`, so a worker busy with `--concurrency=2` tasks under a 1000m CPU limit fails a probe it should pass. Pass `-t 15` and probe every 60s instead of every 30s.

Readiness is dropped: the worker fronts no Service, so it only gated rollouts, and a second Python start-up per period competed with the tasks for the same CPU limit. `CKV_K8S_9` skipped on the Deployment, as on beat.

Trade-off: `3 x 60s` means up to three minutes before a genuinely wedged worker is restarted, against roughly 90s before.

Also bumps the chart to 0.3.0 and appVersion to 1.4.1.
