### PR TITLE
Add opt-in preStop lifecycle hook to all charts

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/backstage
   - https://github.com/BSStudio/backstage
 type: application
-version: 0.1.0
+version: 0.2.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main](https://img.shields.io/badge/AppVersion-main-informational?style=flat-square)
 
 Internal member portal for Budavári Schönherz Stúdió, and the source of truth for member data.
 
@@ -68,6 +68,7 @@ Kubernetes: `>=1.23.0-0`
 | ingress.hosts | list | `[]` | List of ingress hosts. Must match `config.BETTER_AUTH_URL`, where the OIDC callback lands. |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | Init containers to add to the deployment |
+| lifecycle | object | `{}` | Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal has propagated, and is charged against `terminationGracePeriodSeconds`. |
 | livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":10,"periodSeconds":10,"tcpSocket":{"port":"http"}}` | Liveness probe for the container. `tcpSocket`, not `/api/health`: that endpoint queries the database. |
 | nameOverride | string | `""` | Provide a name in place of `backstage` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |

--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -124,6 +124,13 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 40
 
+# -- Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal
+# has propagated, and is charged against `terminationGracePeriodSeconds`.
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sleep", "10"]
+
 resources:
   limits:
     # -- The maximum amount of CPU the container can use

--- a/charts/mattermost/Chart.yaml
+++ b/charts/mattermost/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/BSStudio/mattermost-oidc
   - https://github.com/mattermost/mattermost
 type: application
-version: 1.0.1
+version: 1.1.0

--- a/charts/mattermost/README.md
+++ b/charts/mattermost/README.md
@@ -1,6 +1,6 @@
 # mattermost
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.9.0](https://img.shields.io/badge/AppVersion-11.9.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 11.9.0](https://img.shields.io/badge/AppVersion-11.9.0-informational?style=flat-square)
 
 Mattermost Team Edition with OIDC single sign-on and the user limit lifted.
 
@@ -51,6 +51,7 @@ Kubernetes: `>=1.21.0-0`
 | ingress.hosts | list | `[]` | List of ingress hosts |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | Init containers to add to the deployment |
+| lifecycle | object | `{}` | Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal has propagated, and is charged against `terminationGracePeriodSeconds`. |
 | livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":10,"periodSeconds":10,"tcpSocket":{"port":"http"}}` | Liveness probe for the container. `tcpSocket`, not the ping endpoint: a ping that reaches the database would restart every replica during a database blip, which cannot fix it. |
 | nameOverride | string | `""` | Provide a name in place of `mattermost` |
 | nodeSelector | object | `{}` | NodeSelector for the deployment |

--- a/charts/mattermost/templates/deployment.yaml
+++ b/charts/mattermost/templates/deployment.yaml
@@ -66,6 +66,10 @@ spec:
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/mattermost/values.yaml
+++ b/charts/mattermost/values.yaml
@@ -125,6 +125,13 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 30
 
+# -- Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal
+# has propagated, and is charged against `terminationGracePeriodSeconds`.
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sleep", "10"]
+
 resources:
   limits:
     # -- The maximum amount of CPU the container can use

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -31,4 +31,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/outline
   - https://github.com/outline/outline
 type: application
-version: 2.0.2
+version: 2.1.0

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -1,6 +1,6 @@
 # outline
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.2](https://img.shields.io/badge/AppVersion-1.9.2-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.2](https://img.shields.io/badge/AppVersion-1.9.2-informational?style=flat-square)
 
 Outline is a fast, collaborative, knowledge base for your team built using React and Node.js.
 
@@ -92,6 +92,7 @@ previously had to be kept in sync with the password embedded in `outline.databas
 | ingress.hosts | list | `[]` | List of ingress hosts |
 | ingress.tls | list | `[]` | Ingress TLS configuration |
 | initContainers | list | `[]` | Init containers to add to the deployment |
+| lifecycle | object | `{}` | Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal has propagated, and is charged against `terminationGracePeriodSeconds`. |
 | livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"tcpSocket":{"port":"http"}}` | Liveness probe for the container. Not /_health: it queries Postgres and Redis, so an outage would restart every replica. |
 | minio.enabled | bool | `false` | Enable the CloudPirates MinIO® chart. Refer to <https://github.com/CloudPirates-io/helm-charts/blob/main/charts/minio> for possible values. |
 | nameOverride | string | `""` | Provide a name in place of `outline` |

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -121,6 +121,13 @@ startupProbe:
   periodSeconds: 10
   failureThreshold: 30
 
+# -- Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal
+# has propagated, and is charged against `terminationGracePeriodSeconds`.
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sleep", "10"]
+
 resources:
   limits:
     # -- The maximum amount of CPU the container can use

--- a/charts/request-manager/Chart.yaml
+++ b/charts/request-manager/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/BSStudio/helm-charts/tree/main/charts/request-manager
   - https://github.com/BSStudio/request-manager
 type: application
-version: 0.3.1
+version: 0.4.0

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -104,7 +104,7 @@ Kubernetes: `>=1.23.0-0`
 | server.autoscaling.maxReplicas | int | `10` | Maximum number of server replicas |
 | server.autoscaling.minReplicas | int | `1` | Minimum number of server replicas |
 | server.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage that triggers scaling |
-| server.lifecycle | object | `{}` | Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal has propagated. It is charged against `terminationGracePeriodSeconds`, which already only matches Gunicorn's `--graceful-timeout` — raise it alongside, or the sleep eats into the drain. |
+| server.lifecycle | object | `{}` | Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal has propagated, and is charged against `terminationGracePeriodSeconds`. |
 | server.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":"http"},"initialDelaySeconds":10,"periodSeconds":10}` | Liveness probe for the server container |
 | server.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the server deployment |
 | server.pdb.maxUnavailable | string | `""` | Maximum unavailable server pods (takes precedence over minAvailable when set) |
@@ -119,7 +119,7 @@ Kubernetes: `>=1.23.0-0`
 | server.service.type | string | `"ClusterIP"` | Kubernetes service type for HTTP traffic |
 | server.startupProbe | object | `{"failureThreshold":30,"httpGet":{"path":"/livez","port":"http"},"initialDelaySeconds":10,"periodSeconds":10}` | Startup probe for the server container |
 | server.strategy | object | `{}` | Deployment update strategy for the server workload |
-| server.terminationGracePeriodSeconds | int | `30` | Grace period for the server pod to finish in-flight requests on shutdown |
+| server.terminationGracePeriodSeconds | int | `45` | Grace period for the server pod to finish in-flight requests on shutdown. Above Gunicorn's `--graceful-timeout=30`, so a `lifecycle.preStop` sleep does not eat into the drain. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/request-manager/README.md
+++ b/charts/request-manager/README.md
@@ -1,6 +1,6 @@
 # request-manager
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 Manage video shooting and live streaming requests at Budavári Schönherz Stúdió.
 
@@ -104,6 +104,7 @@ Kubernetes: `>=1.23.0-0`
 | server.autoscaling.maxReplicas | int | `10` | Maximum number of server replicas |
 | server.autoscaling.minReplicas | int | `1` | Minimum number of server replicas |
 | server.autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage that triggers scaling |
+| server.lifecycle | object | `{}` | Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal has propagated. It is charged against `terminationGracePeriodSeconds`, which already only matches Gunicorn's `--graceful-timeout` — raise it alongside, or the sleep eats into the drain. |
 | server.livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":"http"},"initialDelaySeconds":10,"periodSeconds":10}` | Liveness probe for the server container |
 | server.pdb.enabled | bool | `false` | Enable a PodDisruptionBudget for the server deployment |
 | server.pdb.maxUnavailable | string | `""` | Maximum unavailable server pods (takes precedence over minAvailable when set) |

--- a/charts/request-manager/templates/server/deployment.yaml
+++ b/charts/request-manager/templates/server/deployment.yaml
@@ -80,6 +80,10 @@ spec:
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.server.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
           volumeMounts:

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -59,8 +59,9 @@ affinity: {}
 server:
   # -- Number of Gunicorn server replicas (ignored when autoscaling is enabled)
   replicaCount: 1
-  # -- Grace period for the server pod to finish in-flight requests on shutdown
-  terminationGracePeriodSeconds: 30
+  # -- Grace period for the server pod to finish in-flight requests on shutdown. Above Gunicorn's
+  # `--graceful-timeout=30`, so a `lifecycle.preStop` sleep does not eat into the drain.
+  terminationGracePeriodSeconds: 45
   # -- Container args (passed to the image entrypoint). Overrides the default Gunicorn command.
   args:
     - gunicorn
@@ -108,8 +109,7 @@ server:
     periodSeconds: 10
     failureThreshold: 30
   # -- Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal
-  # has propagated. It is charged against `terminationGracePeriodSeconds`, which already only matches
-  # Gunicorn's `--graceful-timeout` — raise it alongside, or the sleep eats into the drain.
+  # has propagated, and is charged against `terminationGracePeriodSeconds`.
   lifecycle: {}
     # preStop:
     #   exec:

--- a/charts/request-manager/values.yaml
+++ b/charts/request-manager/values.yaml
@@ -107,6 +107,13 @@ server:
     initialDelaySeconds: 10
     periodSeconds: 10
     failureThreshold: 30
+  # -- Container lifecycle hooks. A `preStop` sleep holds the pod open until its endpoint removal
+  # has propagated. It is charged against `terminationGracePeriodSeconds`, which already only matches
+  # Gunicorn's `--graceful-timeout` — raise it alongside, or the sleep eats into the drain.
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command: ["/bin/sleep", "10"]
   resources:
     limits:
       # -- The maximum amount of CPU the container can use


### PR DESCRIPTION
## Why

Pod deletion starts two things at once, with no ordering between them: the kubelet sends SIGTERM to the container, and the endpoint controller removes the pod from its EndpointSlice so kube-proxy and the ingress controller can reprogram. The app therefore routinely stops accepting connections before the last proxy has learned it is gone, which shows up as 502s and connection-refused during rollouts, node drains and scale-downs.

No application-side shutdown handling fixes this — the race is outside the process. The standard remedy is a `preStop` sleep that delays SIGTERM until endpoint removal has propagated, so the pod keeps serving through the window.